### PR TITLE
Fix topic page visibility and associations

### DIFF
--- a/content/concurrency/concurrent-http-virtual.yaml
+++ b/content/concurrency/concurrent-http-virtual.yaml
@@ -54,6 +54,7 @@ related:
 tags:
 - virtual-threads
 - concurrency
+- http
 docs:
 - title: "Virtual Threads (JEP 444)"
   href: "https://openjdk.org/jeps/444"

--- a/content/concurrency/executor-try-with-resources.yaml
+++ b/content/concurrency/executor-try-with-resources.yaml
@@ -49,7 +49,6 @@ related:
 - "concurrency/virtual-threads"
 - "concurrency/thread-sleep-duration"
 tags:
-- virtual-threads
 - concurrency
 docs:
 - title: "ExecutorService"

--- a/content/datetime/date-formatting.yaml
+++ b/content/datetime/date-formatting.yaml
@@ -47,6 +47,7 @@ related:
 - "datetime/hex-format"
 tags:
 - datetime
+- formatting
 docs:
 - title: "DateTimeFormatter"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/time/format/DateTimeFormatter.html"

--- a/content/enterprise/mdb-vs-reactive-messaging.yaml
+++ b/content/enterprise/mdb-vs-reactive-messaging.yaml
@@ -67,6 +67,7 @@ related:
 tags:
 - enterprise
 - reactive
+- async
 docs:
 - title: "MicroProfile Reactive Messaging Specification"
   href: "https://download.eclipse.org/microprofile/microprofile-reactive-messaging-3.0/microprofile-reactive-messaging-spec-3.0.html"

--- a/content/enterprise/spring-null-safety-jspecify.yaml
+++ b/content/enterprise/spring-null-safety-jspecify.yaml
@@ -85,6 +85,7 @@ related:
 tags:
 - null-safety
 - spring
+- enterprise
 docs:
 - title: "Spring Framework 7 — Null Safety"
   href: "https://docs.spring.io/spring-framework/reference/core/null-safety.html"

--- a/content/errors/helpful-npe.yaml
+++ b/content/errors/helpful-npe.yaml
@@ -45,6 +45,7 @@ related:
 - "errors/require-nonnull-else"
 tags:
 - null-safety
+- exceptions
 docs:
 - title: "Helpful NullPointerExceptions (JEP 358)"
   href: "https://openjdk.org/jeps/358"

--- a/content/errors/optional-orelsethrow.yaml
+++ b/content/errors/optional-orelsethrow.yaml
@@ -47,6 +47,7 @@ related:
 tags:
 - optional
 - null-safety
+- exceptions
 docs:
 - title: "Optional.orElseThrow()"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Optional.html#orElseThrow()"

--- a/content/errors/record-based-errors.yaml
+++ b/content/errors/record-based-errors.yaml
@@ -52,8 +52,6 @@ related:
 - "errors/multi-catch"
 tags:
 - records
-- exceptions
-- sealed-classes
 docs:
 - title: "Records (JEP 395)"
   href: "https://openjdk.org/jeps/395"

--- a/content/errors/require-nonnull-else.yaml
+++ b/content/errors/require-nonnull-else.yaml
@@ -44,7 +44,6 @@ related:
 - "errors/optional-chaining"
 tags:
 - null-safety
-- optional
 docs:
 - title: "Objects.requireNonNullElse()"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Objects.html#requireNonNullElse(T,T)"

--- a/content/io/deserialization-filters.yaml
+++ b/content/io/deserialization-filters.yaml
@@ -49,6 +49,7 @@ related:
 tags:
 - security
 - serialization
+- io
 docs:
 - title: "ObjectInputFilter"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/io/ObjectInputFilter.html"

--- a/content/io/file-memory-mapping.yaml
+++ b/content/io/file-memory-mapping.yaml
@@ -60,6 +60,8 @@ related:
 - "io/writing-files"
 tags:
 - io
+- foreign-function-api
+- performance
 docs:
 - title: "MemorySegment (Java 22)"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/foreign/MemorySegment.html"

--- a/content/io/http-client.yaml
+++ b/content/io/http-client.yaml
@@ -50,6 +50,7 @@ related:
 - "io/try-with-resources-effectively-final"
 tags:
 - http
+- io
 docs:
 - title: "HttpClient (JEP 321)"
   href: "https://openjdk.org/jeps/321"

--- a/content/language/compact-canonical-constructor.yaml
+++ b/content/language/compact-canonical-constructor.yaml
@@ -55,6 +55,7 @@ related:
 - "errors/record-based-errors"
 tags:
 - records
+- constructors
 docs:
 - title: "Record (Java 21)"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/Record.html"

--- a/content/language/default-interface-methods.yaml
+++ b/content/language/default-interface-methods.yaml
@@ -63,7 +63,6 @@ related:
 - "language/sealed-classes"
 tags:
 - interfaces
-- functional
 docs:
 - title: "Evolving Interfaces (dev.java)"
   href: "https://dev.java/learn/interfaces/examples/"

--- a/content/language/guarded-patterns.yaml
+++ b/content/language/guarded-patterns.yaml
@@ -55,7 +55,6 @@ related:
 tags:
 - pattern-matching
 - switch
-- records
 docs:
 - title: "Pattern Matching for switch (JEP 441)"
   href: "https://openjdk.org/jeps/441"

--- a/content/language/text-blocks-for-multiline-strings.yaml
+++ b/content/language/text-blocks-for-multiline-strings.yaml
@@ -46,6 +46,7 @@ related:
 - "language/exhaustive-switch"
 tags:
 - text-blocks
+- strings
 docs:
 - title: "Text Blocks (JEP 378)"
   href: "https://openjdk.org/jeps/378"

--- a/content/security/random-generator.yaml
+++ b/content/security/random-generator.yaml
@@ -51,7 +51,7 @@ related:
 - "security/key-derivation-functions"
 - "concurrency/virtual-threads"
 tags:
-- security
+- random-number-generation
 docs:
 - title: "RandomGenerator"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/random/RandomGenerator.html"

--- a/content/security/strong-random.yaml
+++ b/content/security/strong-random.yaml
@@ -48,6 +48,7 @@ related:
 tags:
 - security
 - cryptography
+- random-number-generation
 docs:
 - title: "SecureRandom"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/security/SecureRandom.html"

--- a/content/security/tls-default.yaml
+++ b/content/security/tls-default.yaml
@@ -47,6 +47,7 @@ related:
 - "security/strong-random"
 tags:
 - security
+- cryptography
 docs:
 - title: "SSLContext"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/javax/net/ssl/SSLContext.html"

--- a/content/streams/stream-of-nullable.yaml
+++ b/content/streams/stream-of-nullable.yaml
@@ -40,7 +40,7 @@ related:
 - "streams/stream-gatherers"
 tags:
 - streams
-- optional
+- null-safety
 docs:
 - title: "Stream.ofNullable()"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/stream/Stream.html#ofNullable(T)"

--- a/content/strings/string-formatted.yaml
+++ b/content/strings/string-formatted.yaml
@@ -42,6 +42,7 @@ related:
 - "strings/string-indent-transform"
 tags:
 - strings
+- formatting
 docs:
 - title: "String.formatted()"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/String.html#formatted(java.lang.Object...)"

--- a/content/strings/string-indent-transform.yaml
+++ b/content/strings/string-indent-transform.yaml
@@ -47,6 +47,7 @@ related:
 - "strings/string-lines"
 tags:
 - strings
+- formatting
 docs:
 - title: "String.indent()"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/String.html#indent(int)"

--- a/content/tooling/aot-class-preloading.yaml
+++ b/content/tooling/aot-class-preloading.yaml
@@ -49,6 +49,7 @@ related:
 - "tooling/multi-file-source"
 tags:
 - performance
+- tooling
 docs:
 - title: "Ahead-of-Time Command-Line Ergonomics (JEP 514)"
   href: "https://openjdk.org/jeps/514"

--- a/content/tooling/compact-object-headers.yaml
+++ b/content/tooling/compact-object-headers.yaml
@@ -45,6 +45,7 @@ related:
 - "tooling/multi-file-source"
 tags:
 - performance
+- tooling
 docs:
 - title: "Compact Object Headers (JEP 519)"
   href: "https://openjdk.org/jeps/519"

--- a/content/tooling/junit6-with-jspecify.yaml
+++ b/content/tooling/junit6-with-jspecify.yaml
@@ -96,6 +96,7 @@ related:
 tags:
 - testing
 - null-safety
+- tooling
 docs:
 - title: "JUnit 6 Assertions API"
   href: "https://docs.junit.org/current/api/org.junit.jupiter.api/org/junit/jupiter/api/Assertions.html"

--- a/html-generators/generate.java
+++ b/html-generators/generate.java
@@ -294,7 +294,7 @@ void buildLocale(String locale, Templates templates, SequencedMap<String, Snippe
 
     // Generate index.html from template
     var tipCards = allSnippets.values().stream()
-            .map(s -> renderIndexCard(templates.indexCard(), resolveSnippet(s, locale), locale, strings))
+            .map(s -> renderIndexCard(templates.indexCard(), resolveSnippet(s, locale), locale, strings, true))
             .collect(Collectors.joining("\n"));
 
     var indexTokens = new LinkedHashMap<String, String>();
@@ -397,7 +397,8 @@ String renderNavArrows(Snippet snippet, String locale) {
     return prev + "\n          " + next;
 }
 
-String renderIndexCard(String tpl, Snippet s, String locale, Map<String, String> strings) {
+String renderIndexCard(String tpl, Snippet s, String locale, Map<String, String> strings,
+                       boolean initiallyHidden) {
     var cardHref = locale.equals("en")
             ? "/%s/%s.html".formatted(s.category(), s.slug())
             : "/%s/%s/%s.html".formatted(locale, s.category(), s.slug());
@@ -407,6 +408,7 @@ String renderIndexCard(String tpl, Snippet s, String locale, Map<String, String>
             Map.entry("catDisplay", s.catDisplay()), Map.entry("title", escape(s.title())),
             Map.entry("oldCode", escape(s.oldCode())), Map.entry("modernCode", escape(s.modernCode())),
             Map.entry("jdkVersion", s.jdkVersion()), Map.entry("cardHref", cardHref),
+            Map.entry("initialCardState", initiallyHidden ? " filter-hidden" : ""),
             Map.entry("tags", tagsValue),
             Map.entry("cards.old", strings.getOrDefault("cards.old", "Old")),
             Map.entry("cards.modern", strings.getOrDefault("cards.modern", "Modern")),
@@ -522,7 +524,7 @@ void generateTopicPages(Templates templates, SequencedMap<String, Snippet> allSn
 
         // Render cards for snippets in this topic
         var topicCards = snippetsForTag.stream()
-                .map(s -> renderIndexCard(templates.indexCard(), s, locale, strings))
+                .map(s -> renderIndexCard(templates.indexCard(), s, locale, strings, false))
                 .collect(Collectors.joining("\n"));
 
         var canonicalUrl = "%s/topics/%s.html".formatted(BASE_URL, tag);
@@ -551,7 +553,7 @@ void generateTopicPages(Templates templates, SequencedMap<String, Snippet> allSn
         tokens.put("topics.backToAll", strings.getOrDefault("topics.backToAll", "← All patterns"));
         tokens.put("topicSnippetCount", topicSnippetCount);
         tokens.put("topicCards", topicCards);
-        tokens.put("topicBasePrefix", "../../");
+        tokens.put("topicBasePrefix", "../");
         tokens.put("i18nScript", i18nScript);
 
         var html = replaceTokens(templates.topicPage(), tokens);

--- a/html-generators/tags.properties
+++ b/html-generators/tags.properties
@@ -43,3 +43,4 @@ constructors=Constructors
 collectors=Collectors
 formatting=Formatting
 math=Math
+random-number-generation=Random Number Generation

--- a/site/app.js
+++ b/site/app.js
@@ -17,6 +17,8 @@
 
   /* ---------- Browser Locale Auto-Redirect ---------- */
   const autoRedirectLocale = () => {
+    // Topic pages are canonical English-only pages.
+    if (document.body.dataset.page === 'topic') return;
     if (locale !== 'en') return; // already on a non-English locale
     const available = (window.i18n && window.i18n.availableLocales) || [];
     if (available.length <= 1) return;

--- a/templates/index-card.html
+++ b/templates/index-card.html
@@ -1,4 +1,4 @@
-      <a href="{{cardHref}}" class="tip-card filter-hidden" data-category="{{category}}" data-jdk="{{jdkVersion}}" data-tags="{{tags}}">
+      <a href="{{cardHref}}" class="tip-card{{initialCardState}}" data-category="{{category}}" data-jdk="{{jdkVersion}}" data-tags="{{tags}}">
         <div class="tip-card-body">
           <div class="tip-card-header">
             <div class="tip-badges"><span class="badge {{category}}">{{catDisplay}}</span></div>


### PR DESCRIPTION
Topic links could open pages whose cards remained hidden, and locale auto-detection could redirect canonical English topic pages to localized routes that do not exist. The topic metadata also contained several missing or misleading associations discovered while reviewing the follow-up comment on #156.

## Changes

- Render topic-page cards visible by default while preserving homepage filter behavior.
- Keep English-only topic pages on their canonical routes and correct their asset paths.
- Audit all 113 content files, removing misleading topics and adding directly demonstrated associations.
- Add a dedicated Random Number Generation topic so non-cryptographic RNG APIs are not classified as security features.

## Verification

- Regenerated every locale successfully.
- Validated all 113 content files against the 44-topic taxonomy.
- Confirmed every generated topic page exactly matches its declared content associations.
- Verified the affected topic pages locally in the browser.