### PR TITLE
Add version-aware modern Java agent plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ site/data/snippets.json
 
 # Generated index page (built from templates/index.html by html-generators/)
 site/index.html
+site/agent-plugin.html
 
 # Generated locale directories (built by html-generators/ for non-English locales)
 site/[a-z][a-z]/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ This site uses a **JSON/YAML-first** build pipeline:
 - **Translations**: `translations/strings/{locale}.yaml` for UI strings, `translations/content/{locale}/` for pattern content (YAML)
 - **Deploy**: GitHub Actions runs the generator and deploys to GitHub Pages
 
+### Agent plugin
+
+[`agent-plugins/modern-java-development`](agent-plugins/modern-java-development/)
+is a portable Agent Plugins 1.0 package for version-aware Java development. Its
+skill detects a project's effective compilation target, then limits guidance to
+final language features and APIs available in that Java release.
+
 Generated files (`site/category/*.html`, `site/{locale}/`, and `site/data/snippets.json`) are in `.gitignore` — never edit them directly.
 
 ### Internationalization

--- a/agent-plugins/modern-java-development/README.md
+++ b/agent-plugins/modern-java-development/README.md
@@ -1,0 +1,50 @@
+# Modern Java Development agent plugin
+
+A portable [Agent Plugins 1.0](https://agent-plugins.org/specification) package
+for version-aware Java development.
+
+The plugin contributes the `modern-java` skill. The skill detects the project's
+effective Java compilation target before recommending language features, APIs,
+tooling, or modernization changes. Guidance is cumulative and grouped by the
+Java release in which each capability became final.
+
+## Package layout
+
+```text
+modern-java-development/
+├── plugin.json
+└── skills/
+    └── modern-java/
+        ├── SKILL.md
+        ├── references/
+        │   ├── core-practices.md
+        │   └── release-practices.md
+        └── scripts/
+            ├── detect_java_version.py
+            └── test_detect_java_version.py
+```
+
+## Use
+
+Install or copy this directory into any Agent Plugins-compatible client. When
+the skill is active, the agent runs the detector from the Java project root:
+
+```bash
+python3 skills/modern-java/scripts/detect_java_version.py .
+```
+
+Pass an explicit target when build metadata is unavailable:
+
+```bash
+python3 skills/modern-java/scripts/detect_java_version.py . --java-version 21
+```
+
+The detector emits JSON so an agent can distinguish the selected target from
+lower-confidence runtime evidence and report conflicting build configuration.
+
+## Validate
+
+```bash
+python3 -m unittest \
+  skills/modern-java/scripts/test_detect_java_version.py
+```

--- a/agent-plugins/modern-java-development/plugin.json
+++ b/agent-plugins/modern-java-development/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "modern-java-development",
+  "version": "1.0.0",
+  "description": "Version-aware guidance for writing, reviewing, and modernizing Java projects.",
+  "author": {
+    "name": "java.evolved",
+    "url": "https://javaevolved.github.io"
+  },
+  "homepage": "https://javaevolved.github.io",
+  "repository": "https://github.com/javaevolved/javaevolved.github.io",
+  "license": "MIT",
+  "keywords": [
+    "java",
+    "modern-java",
+    "jdk",
+    "code-review",
+    "modernization"
+  ]
+}

--- a/agent-plugins/modern-java-development/skills/modern-java/SKILL.md
+++ b/agent-plugins/modern-java-development/skills/modern-java/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: modern-java
+description: Detects a project's effective Java version and provides release-appropriate guidance for writing, reviewing, refactoring, upgrading, and modernizing Java code. Use for Java implementation, architecture, code review, build configuration, migration, performance, concurrency, testing, or API design tasks.
+license: MIT
+compatibility: Requires Python 3 to run the bundled detector; an agent may inspect the same project files directly when Python is unavailable.
+metadata:
+  author: java.evolved
+  version: "1.0.0"
+---
+
+# Modern Java
+
+Determine the project's effective compilation target before proposing code.
+An installed JDK is only fallback evidence; it does not prove which language
+features or APIs the build accepts.
+
+## Workflow
+
+1. From the project or module root, run:
+
+   ```bash
+   python3 <skill-directory>/scripts/detect_java_version.py .
+   ```
+
+   If the user explicitly supplied Java version X, pass
+   `--java-version X`. Explicit user intent takes precedence over project files.
+
+2. Read the JSON result:
+   - Use `selected.version` as the target.
+   - Treat `maven-release`, `gradle-release`, and explicit overrides as stronger
+     evidence than toolchains, source compatibility, version-manager files, CI,
+     environment variables, or the installed runtime.
+   - If `ambiguous` is true, inspect the listed files and determine which module
+     or build profile is in scope. Do not silently choose the newest version.
+   - If no version is selected, inspect build and CI configuration. If still
+     unknown, state the assumption before writing version-sensitive code.
+
+3. Read [core practices](references/core-practices.md), then read the target
+   release and all earlier applicable groups in
+   [release practices](references/release-practices.md). Recommendations are
+   cumulative: Java 21 code may use final features from Java 21 and below.
+
+4. Inspect whether preview is explicitly enabled (`--enable-preview` in both
+   compile and runtime/test configuration). Do not recommend preview features
+   by default. Never use a feature finalized after the detected target.
+
+5. Tailor the work:
+   - **New code:** prefer the clearest final API available at the target.
+   - **Review:** flag needless legacy patterns only when the replacement is
+     available at the target and fits the behavior.
+   - **Modernization:** separate behavior-preserving refactors from Java target
+     upgrades. Do not raise the target unless requested.
+   - **Libraries:** respect the published minimum Java version, not the
+     maintainer's local JDK.
+   - **Multi-release or multi-module builds:** evaluate each affected source set
+     or module against its own target.
+
+6. Validate with the project's existing build using its configured toolchain.
+   Compile and run tests with the same `--release` and preview settings used by
+   production. Do not treat a successful compile on a newer local JDK as proof
+   of compatibility.
+
+## Recommendation format
+
+When version matters, briefly name the basis:
+
+> Detected Java 17 from `maven.compiler.release`; recommendations are limited to
+> final Java 17 APIs and language features.
+
+For upgrades, distinguish:
+
+- **Usable now:** supported by the current target.
+- **Available after upgrade:** requires a specific newer target.
+- **Preview:** experimental for a specific release and opt-in only.
+
+Prefer small, behavior-preserving changes. Do not mechanically replace every
+older construct: readability, API contracts, allocation behavior, framework
+constraints, and team conventions still apply.

--- a/agent-plugins/modern-java-development/skills/modern-java/references/core-practices.md
+++ b/agent-plugins/modern-java-development/skills/modern-java/references/core-practices.md
@@ -1,0 +1,85 @@
+# Core modern Java practices
+
+Apply these practices at every supported Java version, using only APIs and
+syntax available at the detected compilation target.
+
+## Build and compatibility
+
+- Treat `--release`, Maven `maven.compiler.release`, or Gradle
+  `options.release` as the compatibility contract.
+- Pin a reproducible toolchain in the build and CI. Do not rely solely on
+  `JAVA_HOME` or a developer's installed JDK.
+- For libraries, test the minimum supported Java release. Avoid accidentally
+  linking to APIs from the JDK used to run the build.
+- Keep preview features out of production defaults. If adopted deliberately,
+  enable preview consistently for compilation, tests, execution, packaging,
+  IDEs, and CI, and plan migration at the next release.
+- Prefer supported LTS releases for long-lived production systems unless the
+  organization intentionally follows the six-month release cadence.
+
+## Language and API design
+
+- Model invalid states out of the type system where practical. Use small value
+  types, enums, and sealed hierarchies when the target supports them.
+- Prefer immutable state and explicit ownership. Make defensive copies at
+  mutable boundaries; do not expose modifiable internal collections.
+- Use `Optional` primarily as a return type for an absent single value, not for
+  fields, parameters, collections, or serialization contracts by default.
+- Use exceptions for exceptional failure, with actionable messages and
+  preserved causes. Do not catch broad exceptions or silently continue.
+- Prefer standard JDK APIs over dependencies when they are equally clear and
+  capable, but do not rewrite mature library functionality merely to remove a
+  dependency.
+- Keep public APIs unsurprising. Modern syntax is not a reason to break binary,
+  source, serialization, or framework compatibility.
+
+## Collections, streams, and nullness
+
+- Return empty collections instead of `null`. State mutability and encounter
+  order in API contracts.
+- Use streams for declarative transformations, not for control flow with hidden
+  side effects. Prefer a loop when it is clearer or permits early exit.
+- Do not parallelize streams without measurement and a suitable workload.
+- Establish an explicit nullness policy. Prefer JSpecify annotations when the
+  surrounding ecosystem and tooling support them.
+
+## Concurrency
+
+- Prefer structured ownership of tasks and resources. Always define
+  cancellation, timeout, interruption, and failure propagation behavior.
+- Preserve interruption (`Thread.currentThread().interrupt()`) when an
+  `InterruptedException` cannot be propagated.
+- Use concurrent collections and high-level synchronization utilities before
+  hand-written locking. Document invariants protected by locks.
+- Measure before selecting executors, pool sizes, lock-free structures, or
+  virtual-thread migration. CPU-bound and I/O-bound workloads need different
+  strategies.
+
+## Security and reliability
+
+- Validate untrusted input at boundaries. Avoid native Java serialization for
+  untrusted data; apply deserialization filters where legacy use remains.
+- Use modern TLS defaults, authenticated encryption, `SecureRandom`, and
+  purpose-built password/key derivation APIs. Never invent cryptography.
+- Use try-with-resources for every `AutoCloseable` whose lifetime is locally
+  owned.
+- Add timeouts to network calls and bounded behavior to queues, retries,
+  payloads, and caches.
+
+## Performance and observability
+
+- Measure with JFR, JDK tools, and a representative workload before optimizing.
+- Use JMH for microbenchmarks; include warmup, forks, and consumed results.
+- Prefer simple allocation-friendly code, but do not trade correctness or
+  clarity for speculative micro-optimizations.
+- Include enough context in logs to diagnose failures without exposing secrets
+  or personal data.
+
+## Testing
+
+- Test externally visible behavior and edge cases, not implementation details.
+- Use the project's existing test framework and build. Keep tests deterministic;
+  control clocks, randomness, concurrency, locale, timezone, and filesystem
+  dependencies where relevant.
+- Add focused regression tests for bug fixes and compatibility tests for public
+  APIs or serialized formats.

--- a/agent-plugins/modern-java-development/skills/modern-java/references/release-practices.md
+++ b/agent-plugins/modern-java-development/skills/modern-java/references/release-practices.md
@@ -1,0 +1,166 @@
+# Practices by final Java release
+
+Use the group matching the detected target plus all earlier groups. These are
+capabilities that became final in that release; preview history is intentionally
+excluded. Empty releases are grouped with adjacent releases.
+
+## Java 8 baseline
+
+- Use lambdas and method references when they clarify behavior.
+- Use streams for side-effect-free collection transformations and reductions.
+- Use `java.time` instead of `Date`, `Calendar`, and `SimpleDateFormat`.
+- Use `CompletableFuture` for genuinely asynchronous composition, not as a
+  wrapper around blocking code without an executor strategy.
+- Use default and static interface methods deliberately to evolve APIs.
+
+## Java 9
+
+- Prefer `List.of`, `Set.of`, `Map.of`, and `Map.entry` for small immutable
+  collections; reject nulls intentionally.
+- Use `takeWhile`, `dropWhile`, `Stream.ofNullable`, `Optional.or`, and
+  `ifPresentOrElse` where they directly express intent.
+- Use private interface methods to share implementation among defaults.
+- Use `InputStream.transferTo`, effectively-final resources in
+  try-with-resources, `ProcessHandle`, and the JDK HTTP/2 client incubator only
+  with awareness that the standardized HTTP Client arrives in Java 11.
+- Use modules only with an explicit encapsulation or distribution goal; do not
+  modularize mechanically.
+
+## Java 10
+
+- Use local `var` when the initializer makes the type obvious and the name
+  preserves intent. Avoid it when it hides an important numeric, generic, or
+  domain type.
+- Use `List.copyOf`, `Set.copyOf`, and `Map.copyOf` for immutable snapshots.
+- Use no-argument `Optional.orElseThrow()` for required values.
+
+## Java 11
+
+- Prefer the standardized `java.net.http.HttpClient` for JDK-native HTTP,
+  configuring timeouts and handling interruption.
+- Use `String.isBlank`, `strip`, `lines`, and `repeat` instead of hand-written
+  equivalents.
+- Use `Files.readString`, `writeString`, and `Path.of` for appropriately sized
+  content.
+- Use `Predicate.not` and `Optional.isEmpty` where they improve readability.
+- Run small single-file source programs directly when a full build is needless.
+- Rely on TLS 1.3 defaults where interoperability permits.
+
+## Java 12-13
+
+- Use `Files.mismatch` to compare file content and `Collectors.teeing` for two
+  independent reductions over one stream.
+- Use `String.indent` and `transform` for explicit text pipelines.
+- Do not use switch expressions yet unless preview is intentionally enabled;
+  they become final in Java 14.
+
+## Java 14
+
+- Use switch expressions with `->` and `yield` for value-producing,
+  exhaustively handled decisions.
+- Use helpful NullPointerException diagnostics during development; still
+  validate public inputs with domain-specific messages.
+
+## Java 15
+
+- Use text blocks for multiline SQL, JSON, HTML, and test fixtures while
+  reviewing incidental indentation and escaping.
+- Use `String.formatted` when receiver-oriented formatting reads more clearly
+  than `String.format`.
+
+## Java 16
+
+- Use records for transparent, shallowly immutable data carriers. Defensively
+  copy mutable components in a compact canonical constructor.
+- Use pattern matching for `instanceof` to remove redundant casts.
+- Use `Stream.toList()` when an unmodifiable result is intended; do not assume
+  a particular implementation or null-rejection behavior.
+- Use `mapMulti` when one input emits zero or more outputs without temporary
+  streams.
+- Use `toUnmodifiableList`, `Set`, or `Map` when collector semantics are needed.
+
+## Java 17
+
+- Use sealed classes and interfaces for intentionally closed hierarchies,
+  especially when exhaustive handling is valuable.
+- Use `HexFormat` instead of custom hexadecimal conversion.
+- Use the `RandomGenerator` hierarchy when algorithm selection or modern
+  pseudo-random generators matter; continue using `SecureRandom` for security.
+- Treat strong encapsulation of JDK internals as a migration requirement, not
+  something to bypass permanently with `--add-opens`.
+- Java 17 is the minimum for JUnit 6; use JSpecify-aware nullness tooling when
+  adopting it.
+
+## Java 18-20
+
+- Use the simple web server (`jwebserver`) for local static development, not as
+  a production application server.
+- Use `Thread.sleep(Duration)` and try-with-resources for `ExecutorService`
+  starting in Java 19.
+- Do not recommend record patterns, pattern-switch, or virtual threads as final
+  features before Java 21.
+
+## Java 21
+
+- Use virtual threads for high-throughput workloads dominated by blocking I/O.
+  Do not pool virtual threads, and audit pinning, `ThreadLocal` usage, native
+  calls, rate limits, and downstream capacity.
+- Use record patterns and final pattern matching for switch for concise,
+  exhaustive data-oriented logic.
+- Use sequenced collection APIs (`getFirst`, `getLast`, `reversed`) instead of
+  index arithmetic or copied reversals.
+- Use `Math.clamp` for bounded numeric values.
+- Structured concurrency and scoped values are preview APIs in Java 21; do not
+  present them as final for this target.
+
+## Java 22
+
+- Use unnamed variables and patterns (`_`) when a binding is intentionally
+  unused.
+- Use the Foreign Function & Memory API for supported native interop instead of
+  introducing new JNI where its constraints fit. Make arena lifetime and thread
+  confinement explicit.
+- Use the multi-file source launcher for small source-only programs.
+- Use `FileChannel.map` with arenas for explicit mapped-memory lifetime.
+- Do not use stream gatherers or module import declarations as final features.
+
+## Java 23
+
+- Use Markdown documentation comments when they improve maintainability of
+  prose-heavy Javadoc.
+- Continue treating module import declarations, compact source files, and
+  primitive patterns as preview features.
+
+## Java 24
+
+- Use stream gatherers for reusable stateful intermediate stream operations
+  when standard operations cannot express the transformation clearly.
+- Consider class-file API and related platform capabilities only when the task
+  actually manipulates bytecode; prefer standard APIs over internal ASM copies.
+- Structured concurrency, scoped values, and compact source files remain
+  preview in Java 24.
+
+## Java 25
+
+- Use scoped values for bounded, immutable context propagation, especially with
+  virtual threads; do not use them as mutable globals.
+- Use compact source files and instance `main` methods for scripts, teaching,
+  and small programs; retain conventional classes where frameworks or public
+  APIs expect them.
+- Use module import declarations sparingly where broad imports improve small
+  source files without obscuring ownership.
+- Use flexible constructor bodies while preserving the rule that an object
+  cannot be observed before superclass construction.
+- Use the PEM encoding API and key derivation function API instead of hand-made
+  parsing or cryptographic constructions.
+- Evaluate compact object headers and AOT ergonomics with measurements and
+  deployment-specific startup, footprint, and compatibility goals.
+- Structured concurrency and primitive types in patterns are preview in Java
+  25 and require explicit preview configuration. Do not recommend them by
+  default.
+
+## Later or unknown targets
+
+Do not assume features beyond Java 25 from this guide. Verify final status
+against the OpenJDK JEP index and the target release documentation. Clearly
+label any preview or incubating API and confirm the exact release syntax.

--- a/agent-plugins/modern-java-development/skills/modern-java/scripts/detect_java_version.py
+++ b/agent-plugins/modern-java-development/skills/modern-java/scripts/detect_java_version.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Detect a Java project's effective compilation target."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+IGNORED_DIRS = {
+    ".git",
+    ".gradle",
+    ".idea",
+    ".mvn",
+    ".vscode",
+    "build",
+    "node_modules",
+    "out",
+    "target",
+}
+
+SOURCE_PRIORITY = {
+    "explicit": 100,
+    "maven-release": 90,
+    "gradle-release": 90,
+    "maven-toolchain": 80,
+    "gradle-toolchain": 80,
+    "maven-source": 70,
+    "gradle-source": 70,
+    "java-version-file": 60,
+    "sdkman": 60,
+    "asdf": 60,
+    "ci": 50,
+    "environment": 40,
+    "runtime": 10,
+}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    version: int
+    source: str
+    location: str
+    raw: str
+    priority: int
+
+
+def normalize_version(value: str | int | None) -> int | None:
+    if value is None:
+        return None
+    text = str(value).strip().strip("\"'")
+    match = re.search(r"(?<!\d)(?:1\.)?(\d{1,3})(?:[._+-]\d+)*", text)
+    if not match:
+        return None
+    version = int(match.group(1))
+    if text.startswith("1.") and version == 1:
+        legacy = re.match(r"1\.(\d+)", text)
+        return int(legacy.group(1)) if legacy else None
+    return version if version >= 5 else None
+
+
+def add_candidate(
+    candidates: list[Candidate],
+    value: str | int | None,
+    source: str,
+    location: Path | str,
+) -> None:
+    version = normalize_version(value)
+    if version is not None:
+        candidates.append(
+            Candidate(
+                version=version,
+                source=source,
+                location=str(location),
+                raw=str(value).strip(),
+                priority=SOURCE_PRIORITY[source],
+            )
+        )
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def resolve_maven_value(value: str, properties: dict[str, str]) -> str:
+    seen: set[str] = set()
+    current = value.strip()
+    while True:
+        match = re.fullmatch(r"\$\{([^}]+)}", current)
+        if not match or match.group(1) in seen:
+            return current
+        key = match.group(1)
+        seen.add(key)
+        current = properties.get(key, current).strip()
+
+
+def inspect_maven(path: Path, candidates: list[Candidate]) -> None:
+    try:
+        root = ET.parse(path).getroot()
+    except (ET.ParseError, OSError):
+        return
+
+    properties: dict[str, str] = {}
+    for element in root.iter():
+        if local_name(element.tag) == "properties":
+            for child in element:
+                if child.text:
+                    properties[local_name(child.tag)] = child.text.strip()
+
+    release_names = {"maven.compiler.release", "release"}
+    source_names = {"maven.compiler.source", "source"}
+    for element in root.iter():
+        name = local_name(element.tag)
+        if name == "jdkToolchain":
+            for child in element.iter():
+                if local_name(child.tag) == "version" and child.text:
+                    add_candidate(
+                        candidates,
+                        resolve_maven_value(child.text, properties),
+                        "maven-toolchain",
+                        path,
+                    )
+            continue
+        if not element.text:
+            continue
+        value = resolve_maven_value(element.text, properties)
+        if name in release_names:
+            add_candidate(candidates, value, "maven-release", path)
+        elif name in source_names:
+            add_candidate(candidates, value, "maven-source", path)
+
+    for key in ("java.version", "jdk.version"):
+        if key in properties:
+            add_candidate(candidates, properties[key], "maven-source", path)
+
+
+def inspect_gradle(path: Path, candidates: list[Candidate]) -> None:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return
+
+    patterns = [
+        (
+            "gradle-release",
+            r"(?:options\.)?release(?:\.set)?\s*\(?\s*(\d{1,3})",
+        ),
+        (
+            "gradle-toolchain",
+            r"JavaLanguageVersion\.of\s*\(\s*(\d{1,3})\s*\)",
+        ),
+        (
+            "gradle-source",
+            r"(?:sourceCompatibility|targetCompatibility)\s*=\s*"
+            r"(?:JavaVersion\.VERSION_)?[\"']?(?:1[_.])?(\d{1,3})",
+        ),
+    ]
+    for source, pattern in patterns:
+        for match in re.finditer(pattern, text):
+            add_candidate(candidates, match.group(1), source, path)
+
+
+def inspect_version_files(root: Path, candidates: list[Candidate]) -> None:
+    files = [
+        (".java-version", "java-version-file"),
+        (".sdkmanrc", "sdkman"),
+        (".tool-versions", "asdf"),
+    ]
+    for filename, source in files:
+        path = root / filename
+        if not path.is_file():
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        if filename == ".sdkmanrc":
+            match = re.search(r"(?m)^\s*java\s*=\s*(\S+)", text)
+            value = match.group(1) if match else None
+        elif filename == ".tool-versions":
+            match = re.search(r"(?m)^\s*java\s+(\S+)", text)
+            value = match.group(1) if match else None
+        else:
+            value = text.splitlines()[0] if text.splitlines() else None
+        add_candidate(candidates, value, source, path)
+
+
+def inspect_ci(root: Path, candidates: list[Candidate]) -> None:
+    workflows = root / ".github" / "workflows"
+    if not workflows.is_dir():
+        return
+    for path in sorted((*workflows.glob("*.yml"), *workflows.glob("*.yaml"))):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for match in re.finditer(
+            r"(?m)^\s*java-version\s*:\s*[\"']?([^\"'\s#]+)", text
+        ):
+            add_candidate(candidates, match.group(1), "ci", path)
+
+
+def build_files(root: Path, max_depth: int) -> list[Path]:
+    result: list[Path] = []
+    for current, dirs, files in os.walk(root):
+        current_path = Path(current)
+        depth = len(current_path.relative_to(root).parts)
+        dirs[:] = [
+            item
+            for item in dirs
+            if item not in IGNORED_DIRS and depth < max_depth
+        ]
+        for filename in files:
+            if filename in {"pom.xml", "build.gradle", "build.gradle.kts"}:
+                result.append(current_path / filename)
+    return sorted(result)
+
+
+def runtime_version() -> tuple[str | None, str | None]:
+    try:
+        process = subprocess.run(
+            ["java", "-XshowSettings:properties", "-version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None, None
+    output = process.stdout + process.stderr
+    match = re.search(r"java\.specification\.version\s*=\s*(\S+)", output)
+    return (match.group(1), "java on PATH") if match else (None, None)
+
+
+def detect(root: Path, explicit: str | None, max_depth: int) -> dict[str, object]:
+    candidates: list[Candidate] = []
+    if explicit:
+        add_candidate(candidates, explicit, "explicit", "command line")
+
+    for path in build_files(root, max_depth):
+        if path.name == "pom.xml":
+            inspect_maven(path, candidates)
+        else:
+            inspect_gradle(path, candidates)
+
+    inspect_version_files(root, candidates)
+    inspect_ci(root, candidates)
+    add_candidate(candidates, os.environ.get("JAVA_VERSION"), "environment", "JAVA_VERSION")
+    value, location = runtime_version()
+    add_candidate(candidates, value, "runtime", location or "java on PATH")
+
+    unique = list(
+        {
+            (item.version, item.source, item.location, item.raw): item
+            for item in candidates
+        }.values()
+    )
+    ordered = sorted(
+        unique,
+        key=lambda item: (-item.priority, item.location, item.version),
+    )
+    selected = ordered[0] if ordered else None
+    strongest = [item for item in ordered if selected and item.priority == selected.priority]
+    ambiguous = len({item.version for item in strongest}) > 1
+    conflicts = [
+        item
+        for item in ordered
+        if selected and item.version != selected.version and item.priority >= 70
+    ]
+
+    return {
+        "root": str(root),
+        "selected": asdict(selected) if selected else None,
+        "ambiguous": ambiguous,
+        "conflicts": [asdict(item) for item in conflicts],
+        "candidates": [asdict(item) for item in ordered],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect the effective Java compilation target for a project."
+    )
+    parser.add_argument("path", nargs="?", default=".", help="project root")
+    parser.add_argument(
+        "--java-version",
+        help="explicit target supplied by the user (highest precedence)",
+    )
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=3,
+        help="maximum build-file search depth (default: 3)",
+    )
+    args = parser.parse_args()
+
+    root = Path(args.path).expanduser().resolve()
+    if not root.is_dir():
+        print(json.dumps({"error": f"not a directory: {root}"}), file=sys.stderr)
+        return 2
+    if args.java_version and normalize_version(args.java_version) is None:
+        print(
+            json.dumps({"error": f"invalid Java version: {args.java_version}"}),
+            file=sys.stderr,
+        )
+        return 2
+
+    result = detect(root, args.java_version, max(0, args.max_depth))
+    print(json.dumps(result, indent=2))
+    return 0 if result["selected"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent-plugins/modern-java-development/skills/modern-java/scripts/test_detect_java_version.py
+++ b/agent-plugins/modern-java-development/skills/modern-java/scripts/test_detect_java_version.py
@@ -1,0 +1,120 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import detect_java_version as detector
+
+
+class DetectJavaVersionTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def detect(self, explicit=None):
+        with (
+            patch.object(detector, "runtime_version", return_value=("25", "java on PATH")),
+            patch.dict(os.environ, {"JAVA_VERSION": ""}, clear=False),
+        ):
+            return detector.detect(self.root, explicit, 3)
+
+    def test_maven_release_resolves_property_and_beats_runtime(self):
+        (self.root / "pom.xml").write_text(
+            """
+            <project>
+              <properties><java.version>17</java.version></properties>
+              <build><plugins><plugin><configuration>
+                <release>${java.version}</release>
+              </configuration></plugin></plugins></build>
+            </project>
+            """,
+            encoding="utf-8",
+        )
+
+        result = self.detect()
+
+        self.assertEqual(17, result["selected"]["version"])
+        self.assertEqual("maven-release", result["selected"]["source"])
+        self.assertFalse(result["ambiguous"])
+
+    def test_gradle_release_beats_toolchain(self):
+        (self.root / "build.gradle.kts").write_text(
+            """
+            java { toolchain { languageVersion.set(JavaLanguageVersion.of(21)) } }
+            tasks.withType<JavaCompile> { options.release.set(17) }
+            """,
+            encoding="utf-8",
+        )
+
+        result = self.detect()
+
+        self.assertEqual(17, result["selected"]["version"])
+        self.assertEqual("gradle-release", result["selected"]["source"])
+
+    def test_maven_compiler_toolchain_is_detected(self):
+        (self.root / "pom.xml").write_text(
+            """
+            <project><build><plugins><plugin><configuration>
+              <jdkToolchain><version>21</version></jdkToolchain>
+            </configuration></plugin></plugins></build></project>
+            """,
+            encoding="utf-8",
+        )
+
+        result = self.detect()
+
+        self.assertEqual(21, result["selected"]["version"])
+        self.assertEqual("maven-toolchain", result["selected"]["source"])
+
+    def test_version_manager_beats_runtime(self):
+        (self.root / ".java-version").write_text("temurin-21.0.4\n", encoding="utf-8")
+
+        result = self.detect()
+
+        self.assertEqual(21, result["selected"]["version"])
+        self.assertEqual("java-version-file", result["selected"]["source"])
+
+    def test_explicit_version_has_highest_precedence(self):
+        (self.root / "pom.xml").write_text(
+            "<project><properties><maven.compiler.release>17"
+            "</maven.compiler.release></properties></project>",
+            encoding="utf-8",
+        )
+
+        result = self.detect("11")
+
+        self.assertEqual(11, result["selected"]["version"])
+        self.assertEqual("explicit", result["selected"]["source"])
+
+    def test_conflicting_module_releases_are_ambiguous(self):
+        for module, version in (("api", 17), ("app", 21)):
+            directory = self.root / module
+            directory.mkdir()
+            (directory / "pom.xml").write_text(
+                f"<project><properties><maven.compiler.release>{version}"
+                "</maven.compiler.release></properties></project>",
+                encoding="utf-8",
+            )
+
+        result = self.detect()
+
+        self.assertTrue(result["ambiguous"])
+        self.assertEqual({17, 21}, {
+            item["version"]
+            for item in result["candidates"]
+            if item["source"] == "maven-release"
+        })
+
+    def test_legacy_java_version_is_normalized(self):
+        self.assertEqual(8, detector.normalize_version("1.8.0_402"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/html-generators/generate.java
+++ b/html-generators/generate.java
@@ -196,7 +196,8 @@ record Snippet(JsonNode node) {
 }
 
 record Templates(String page, String whyCard, String relatedCard, String socialShare,
-                 String index, String indexCard, String docLink, String topicPage) {
+                 String index, String indexCard, String docLink, String topicPage,
+                 String agentPlugin) {
     static Templates load() throws IOException {
         return new Templates(
             Files.readString(Path.of("templates/slug-template.html")),
@@ -206,7 +207,8 @@ record Templates(String page, String whyCard, String relatedCard, String socialS
             Files.readString(Path.of("templates/index.html")),
             Files.readString(Path.of("templates/index-card.html")),
             Files.readString(Path.of("templates/doc-link.html")),
-            Files.readString(Path.of("templates/topic-page.html")));
+            Files.readString(Path.of("templates/topic-page.html")),
+            Files.readString(Path.of("templates/agent-plugin.html")));
     }
 }
 
@@ -319,6 +321,8 @@ void buildLocale(String locale, Templates templates, SequencedMap<String, Snippe
 
     // Generate topic pages — only for English (canonical); other locales link back to English topics
     if (isEnglish) {
+        Files.writeString(Path.of(SITE_DIR, "agent-plugin.html"), templates.agentPlugin());
+        IO.println("Generated agent-plugin.html");
         generateTopicPages(templates, allSnippets, strings, locale, homeUrl, i18nScript);
     }
 }

--- a/site/app.js
+++ b/site/app.js
@@ -17,8 +17,8 @@
 
   /* ---------- Browser Locale Auto-Redirect ---------- */
   const autoRedirectLocale = () => {
-    // Topic pages are canonical English-only pages.
-    if (document.body.dataset.page === 'topic') return;
+    // Topic and agent plugin pages are canonical English-only pages.
+    if (['topic', 'agent-plugin'].includes(document.body.dataset.page)) return;
     if (locale !== 'en') return; // already on a non-English locale
     const available = (window.i18n && window.i18n.availableLocales) || [];
     if (available.length <= 1) return;

--- a/site/styles.css
+++ b/site/styles.css
@@ -204,6 +204,17 @@ nav {
   gap: 16px;
 }
 
+.plugin-nav-link {
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 600;
+  transition: color 0.2s;
+}
+
+.plugin-nav-link:hover {
+  color: var(--accent);
+}
+
 .cmd-bar {
   display: flex;
   align-items: center;
@@ -309,12 +320,64 @@ nav {
   line-height: 1.7;
 }
 
+.hero-actions,
+.plugin-hero-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.primary-action,
+.secondary-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 10px 18px;
+  border-radius: var(--radius-sm);
+  font-size: 0.9rem;
+  font-weight: 700;
+  transition: background 0.2s, border-color 0.2s, color 0.2s, transform 0.2s;
+}
+
+.primary-action {
+  background: #c2410c;
+  color: #fff;
+  border: 1px solid #c2410c;
+}
+
+.primary-action:hover {
+  background: #9a3412;
+  border-color: #9a3412;
+  transform: translateY(-1px);
+}
+
+.secondary-action {
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border-light);
+}
+
+.secondary-action:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.primary-action:focus-visible,
+.secondary-action:focus-visible,
+.plugin-nav-link:focus-visible {
+  outline: 3px solid var(--blue);
+  outline-offset: 3px;
+}
+
 /* ---------- Hero Compare ---------- */
 .hero-compare {
   display: flex;
   gap: 2px;
   max-width: 820px;
-  margin: 48px auto 0;
+  margin: 36px auto 0;
   border-radius: var(--radius);
   overflow: hidden;
   border: 1px solid var(--border);
@@ -1484,6 +1547,320 @@ footer a:hover {
   color: var(--accent-dim);
 }
 
+/* ---------- Agent Plugin ---------- */
+.plugin-page {
+  --plugin-muted: #a1a1aa;
+  overflow: hidden;
+}
+
+:root[data-theme="light"] .plugin-page {
+  --plugin-muted: #52525b;
+}
+
+.plugin-hero,
+.plugin-mechanism,
+.plugin-features,
+.plugin-usage,
+.plugin-install {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
+.plugin-hero {
+  min-height: 620px;
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(360px, 0.9fr);
+  align-items: center;
+  gap: 64px;
+  padding-top: 80px;
+  padding-bottom: 96px;
+}
+
+.plugin-standard {
+  width: fit-content;
+  margin-bottom: 24px;
+  color: #c2410c;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.plugin-hero h1 {
+  max-width: 680px;
+  font-size: clamp(2.8rem, 6vw, 5.4rem);
+  font-weight: 850;
+  letter-spacing: -0.04em;
+  line-height: 0.98;
+  text-wrap: balance;
+}
+
+.plugin-hero-copy > p {
+  max-width: 620px;
+  margin-top: 28px;
+  color: var(--plugin-muted);
+  font-size: 1.1rem;
+  line-height: 1.75;
+}
+
+.plugin-hero-actions {
+  justify-content: flex-start;
+}
+
+.detector-terminal {
+  overflow: hidden;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  background: #101117;
+  color: #d9d9e2;
+  box-shadow: 18px 24px 55px rgba(0, 0, 0, 0.28);
+  transform: rotate(1.5deg);
+}
+
+.terminal-bar {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 13px 16px;
+  border-bottom: 1px solid #2f3039;
+  background: #191a21;
+}
+
+.terminal-bar span {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #fb7185;
+}
+
+.terminal-bar span:nth-child(2) { background: #fbbf24; }
+.terminal-bar span:nth-child(3) { background: #34d399; }
+
+.terminal-bar strong {
+  margin-left: auto;
+  color: #a1a1aa;
+  font: 500 0.72rem 'JetBrains Mono', monospace;
+}
+
+.terminal-body {
+  padding: 28px;
+  font: 0.83rem/1.9 'JetBrains Mono', monospace;
+}
+
+.terminal-prompt,
+.terminal-key { color: #60a5fa; }
+.terminal-key { display: inline-block; min-width: 78px; }
+.terminal-body strong { color: #fb923c; }
+.terminal-gap { height: 12px; }
+
+.terminal-rule {
+  height: 1px;
+  margin: 17px 0 13px;
+  background: #2f3039;
+}
+
+.terminal-ok { color: #34d399; }
+
+.plugin-mechanism,
+.plugin-features,
+.plugin-usage {
+  padding-top: 96px;
+  padding-bottom: 96px;
+  border-top: 1px solid var(--border);
+}
+
+.plugin-page h2 {
+  max-width: 760px;
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1.08;
+  letter-spacing: -0.035em;
+  text-wrap: balance;
+}
+
+.section-intro {
+  max-width: 720px;
+  margin-top: 20px;
+  color: var(--plugin-muted);
+  font-size: 1.05rem;
+}
+
+.evidence-flow {
+  display: grid;
+  grid-template-columns: 1fr auto 0.85fr;
+  align-items: center;
+  gap: 32px;
+  margin-top: 48px;
+}
+
+.evidence-source {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.evidence-source span {
+  padding: 9px 13px;
+  border: 1px solid var(--border-light);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--plugin-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.evidence-arrow {
+  color: var(--accent);
+  font-size: 2rem;
+}
+
+.evidence-result {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 24px;
+  border: 1px solid var(--blue);
+  border-radius: var(--radius-sm);
+  background: var(--modern-bg);
+}
+
+.evidence-result strong { font-size: 1.05rem; }
+.evidence-result span { color: var(--plugin-muted); font-size: 0.85rem; }
+
+.feature-ledger {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  margin-top: 48px;
+  border-top: 1px solid var(--border-light);
+}
+
+.feature-ledger article {
+  padding: 28px 32px 32px 0;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.feature-ledger article:nth-child(odd) {
+  border-right: 1px solid var(--border-light);
+}
+
+.feature-ledger article:nth-child(even) {
+  padding-left: 32px;
+}
+
+.feature-ledger h3,
+.usage-steps h3 {
+  margin-bottom: 8px;
+  font-size: 1.05rem;
+}
+
+.feature-ledger p,
+.usage-steps p {
+  max-width: 52ch;
+  color: var(--plugin-muted);
+  font-size: 0.9rem;
+}
+
+.usage-steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 32px;
+  margin-top: 48px;
+}
+
+.usage-steps li {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.usage-steps li > span {
+  display: grid;
+  place-items: center;
+  flex: 0 0 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: #c2410c;
+  color: #fff;
+  font-weight: 800;
+}
+
+.prompt-example {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 24px;
+  margin-top: 64px;
+  padding-top: 28px;
+  border-top: 1px solid var(--border-light);
+}
+
+.prompt-example > span {
+  color: #c2410c;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.prompt-example blockquote {
+  max-width: 760px;
+  font-size: clamp(1.15rem, 2.5vw, 1.55rem);
+  font-weight: 650;
+  line-height: 1.5;
+}
+
+.plugin-install {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 56px;
+  max-width: 1052px;
+  margin-top: 48px;
+  margin-bottom: 96px;
+  padding: 56px;
+  border-radius: var(--radius);
+  background: #c2410c;
+  color: #fff;
+}
+
+.plugin-install h2 { font-size: clamp(2rem, 4vw, 3rem); }
+
+.plugin-install p {
+  margin-top: 18px;
+  color: #fff7ed;
+}
+
+.plugin-install a {
+  display: inline-block;
+  margin-top: 24px;
+  font-weight: 750;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.install-command {
+  align-self: center;
+  min-width: 0;
+  padding: 24px;
+  border-radius: var(--radius-sm);
+  background: #101117;
+  color: #d9d9e2;
+  box-shadow: 12px 16px 36px rgba(124, 45, 18, 0.3);
+}
+
+.install-command code {
+  display: block;
+  overflow-x: auto;
+  color: #fb923c;
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.install-command p {
+  margin: 22px 0 8px;
+  color: #7d7f8d;
+  font: 0.72rem 'JetBrains Mono', monospace;
+  text-transform: uppercase;
+}
+
 /* ---------- Responsive: ≤ 700px ---------- */
 @media (max-width: 700px) {
   .nav-links {
@@ -1521,10 +1898,73 @@ footer a:hover {
   .cmd-bar kbd {
     display: none;
   }
+
+  .plugin-nav-link {
+    display: none;
+  }
+
+  .plugin-hero {
+    min-height: auto;
+    grid-template-columns: 1fr;
+    gap: 48px;
+    padding: 64px 20px 72px;
+  }
+
+  .plugin-hero h1 {
+    font-size: clamp(2.6rem, 13vw, 4.2rem);
+  }
+
+  .detector-terminal {
+    transform: none;
+  }
+
+  .plugin-mechanism,
+  .plugin-features,
+  .plugin-usage {
+    padding: 72px 20px;
+  }
+
+  .evidence-flow,
+  .plugin-install {
+    grid-template-columns: 1fr;
+  }
+
+  .evidence-arrow {
+    transform: rotate(90deg);
+    justify-self: start;
+  }
+
+  .feature-ledger,
+  .usage-steps {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-ledger article,
+  .feature-ledger article:nth-child(even) {
+    padding: 24px 0;
+    border-right: 0;
+  }
+
+  .prompt-example {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .plugin-install {
+    width: calc(100% - 32px);
+    margin: 24px 16px 72px;
+    padding: 36px 24px;
+  }
 }
 
 /* ---------- Responsive: ≤ 500px ---------- */
 @media (max-width: 500px) {
+  .hero-actions,
+  .plugin-hero-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
   .hero-compare {
     flex-direction: column;
   }

--- a/templates/agent-plugin.html
+++ b/templates/agent-plugin.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <!--
+    THESIS: Java advice should know the project's real target before it speaks.
+    OWN-WORLD: The existing java.evolved dark/light system, with orange as action and blue as detected state.
+    STORY: See the detector work, understand its safeguards, install the portable package, then use it.
+    FIRST VIEWPORT: A direct promise and install action sit beside a terminal trace of version detection.
+    FORM: A technical field guide arranged around the plugin's detect-bound-recommend mechanism.
+  -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modern Java Agent Plugin | java.evolved</title>
+  <meta name="description" content="Install the java.evolved agent plugin for Java-version-aware development, reviews, refactoring, and modernization guidance.">
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://javaevolved.github.io/agent-plugin.html">
+  <link rel="preload" href="/assets/fonts/inter.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="/assets/fonts/jetbrains-mono.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="icon" href="/favicon.ico" sizes="any">
+  <link rel="icon" href="/favicon-192.png" type="image/png" sizes="192x192">
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+  <meta name="theme-color" content="#f97316">
+  <meta property="og:title" content="Modern Java Agent Plugin | java.evolved">
+  <meta property="og:description" content="Version-aware guidance for writing, reviewing, and modernizing Java projects.">
+  <meta property="og:url" content="https://javaevolved.github.io/agent-plugin.html">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://javaevolved.github.io/images/social-card.png">
+  <style>
+    @font-face{font-family:'Inter';font-style:normal;font-weight:100 900;font-display:swap;src:url('/assets/fonts/inter.woff2') format('woff2')}
+    @font-face{font-family:'JetBrains Mono';font-style:normal;font-weight:400 700;font-display:swap;src:url('/assets/fonts/jetbrains-mono.woff2') format('woff2')}
+  </style>
+  <link rel="stylesheet" href="/styles.css">
+  <script>
+    (function(){var t=localStorage.getItem('theme')||(window.matchMedia('(prefers-color-scheme: light)').matches?'light':'dark');document.documentElement.setAttribute('data-theme',t);})();
+  </script>
+</head>
+<body data-page="agent-plugin">
+  <nav>
+    <div class="nav-inner">
+      <a href="/" class="logo">java.<span>evolved</span></a>
+      <div class="nav-right">
+        <a href="/#all-comparisons" class="plugin-nav-link">Patterns</a>
+        <a href="https://github.com/javaevolved/javaevolved.github.io/tree/main/agent-plugins/modern-java-development" target="_blank" rel="noopener" class="github-link" aria-label="View the agent plugin on GitHub">
+          <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <circle cx="10" cy="10" r="9" fill="none" stroke="currentColor" stroke-width="1.5"/>
+            <path d="M10 3C6.13 3 3 6.13 3 10c0 3.09 2 5.71 4.77 6.63.35.06.48-.15.48-.33v-1.16c-1.95.42-2.36-1.07-2.36-1.07-.32-.81-.78-1.03-.78-1.03-.64-.43.05-.42.05-.42.7.05 1.07.72 1.07.72.63 1.08 1.65.77 2.05.59.06-.46.24-.77.44-.95-1.57-.18-3.22-.78-3.22-3.48 0-.77.27-1.4.72-1.89-.07-.18-.31-.9.07-1.87 0 0 .59-.19 1.93.72.56-.16 1.16-.24 1.76-.24s1.2.08 1.76.24c1.34-.91 1.93-.72 1.93-.72.38.97.14 1.69.07 1.87.45.49.72 1.12.72 1.89 0 2.71-1.65 3.3-3.23 3.47.25.22.48.65.48 1.31v1.94c0 .19.13.4.48.33C15 15.71 17 13.09 17 10c0-3.87-3.13-7-7-7z"/>
+          </svg>
+        </a>
+        <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">☀️</button>
+      </div>
+    </div>
+  </nav>
+
+  <main class="plugin-page">
+    <section class="plugin-hero">
+      <div class="plugin-hero-copy">
+        <div class="plugin-standard">Agent Plugins 1.0 · Portable Agent Skill</div>
+        <h1>Modern Java advice,<br>bounded by your JDK.</h1>
+        <p>The java.evolved agent plugin detects the Java version your project actually targets, then recommends only the final language features, APIs, and practices that version supports.</p>
+        <div class="plugin-hero-actions">
+          <a href="#install" class="primary-action">Install the plugin <span aria-hidden="true">↓</span></a>
+          <a href="https://github.com/javaevolved/javaevolved.github.io/tree/main/agent-plugins/modern-java-development" target="_blank" rel="noopener" class="secondary-action">View source</a>
+        </div>
+      </div>
+      <div class="detector-terminal" aria-label="Example Java version detection result">
+        <div class="terminal-bar">
+          <span></span><span></span><span></span>
+          <strong>version detector</strong>
+        </div>
+        <div class="terminal-body">
+          <div><span class="terminal-prompt">$</span> detect_java_version.py .</div>
+          <div class="terminal-gap"></div>
+          <div><span class="terminal-key">source</span>  maven.compiler.release</div>
+          <div><span class="terminal-key">target</span>  <strong>Java 21</strong></div>
+          <div><span class="terminal-key">preview</span> disabled</div>
+          <div class="terminal-rule"></div>
+          <div class="terminal-ok">✓ Guidance bounded to Java 21</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="plugin-mechanism" aria-labelledby="mechanism-title">
+      <h2 id="mechanism-title">It reads the contract, not just the machine.</h2>
+      <p class="section-intro">An installed JDK does not prove what a project can compile. The detector prioritizes explicit build targets and keeps lower-confidence evidence visible.</p>
+      <div class="evidence-flow">
+        <div class="evidence-source">
+          <span>Maven</span>
+          <span>Gradle</span>
+          <span>Toolchains</span>
+          <span>Version files</span>
+          <span>CI</span>
+          <span>Runtime</span>
+        </div>
+        <div class="evidence-arrow" aria-hidden="true">→</div>
+        <div class="evidence-result">
+          <strong>Effective target</strong>
+          <span>with source, priority, and conflicts</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="plugin-features" aria-labelledby="features-title">
+      <h2 id="features-title">Useful guardrails, built in.</h2>
+      <div class="feature-ledger">
+        <article>
+          <h3>Version-aware by default</h3>
+          <p>Recommendations are cumulative through the detected release, from Java 8 through Java 25.</p>
+        </article>
+        <article>
+          <h3>Preview stays opt-in</h3>
+          <p>Preview and incubating features are never presented as production-ready defaults.</p>
+        </article>
+        <article>
+          <h3>Made for real Java work</h3>
+          <p>Use it for implementation, review, refactoring, upgrades, concurrency, testing, security, and API design.</p>
+        </article>
+        <article>
+          <h3>Portable, vendor-neutral</h3>
+          <p>The package follows the open Agent Plugins 1.0 and Agent Skills specifications.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="plugin-usage" aria-labelledby="usage-title">
+      <h2 id="usage-title">How it works in a session.</h2>
+      <ol class="usage-steps">
+        <li>
+          <span>1</span>
+          <div><h3>Detect</h3><p>The agent inspects the project or module's compilation target and reports conflicting configuration.</p></div>
+        </li>
+        <li>
+          <span>2</span>
+          <div><h3>Bound</h3><p>It loads core practices plus final capabilities from the target release and every earlier release.</p></div>
+        </li>
+        <li>
+          <span>3</span>
+          <div><h3>Recommend</h3><p>It writes, reviews, or modernizes code without silently raising your minimum Java version.</p></div>
+        </li>
+      </ol>
+      <div class="prompt-example">
+        <span>Try asking</span>
+        <blockquote>“Review this service and suggest modern Java improvements without changing its Java 17 target.”</blockquote>
+      </div>
+    </section>
+
+    <section class="plugin-install" id="install" aria-labelledby="install-title">
+      <div>
+        <h2 id="install-title">Install once. Keep the advice honest.</h2>
+        <p>Clone the repository, then register the plugin directory with any Agent Plugins-compatible client. Installation and enablement are controlled by each client.</p>
+        <a href="https://agent-plugins.org/plugin-authors/build-an-agent-plugin" target="_blank" rel="noopener">Read the Agent Plugins specification <span aria-hidden="true">↗</span></a>
+      </div>
+      <div class="install-command">
+        <code>git clone https://github.com/javaevolved/javaevolved.github.io.git</code>
+        <p>Plugin path</p>
+        <code>agent-plugins/modern-java-development</code>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <p><a href="/">java.evolved</a> — Java has evolved. Your code can too.</p>
+    <p><a href="https://github.com/javaevolved/javaevolved.github.io/tree/main/agent-plugins/modern-java-development" target="_blank" rel="noopener">View the agent plugin on GitHub</a></p>
+  </footer>
+
+  <script src="/app.js"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -184,6 +184,7 @@
     <div class="nav-inner">
       <a href="{{homeUrl}}" class="logo">java.<span>evolved</span></a>
       <div class="nav-right">
+        <a href="/agent-plugin.html" class="plugin-nav-link">Agent plugin</a>
         <a href="https://github.com/javaevolved/javaevolved.github.io" target="_blank" rel="noopener" class="github-link" aria-label="{{nav.viewOnGitHub}}">
           <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
             <circle cx="10" cy="10" r="9" fill="none" stroke="currentColor" stroke-width="1.5"/>
@@ -201,6 +202,10 @@
     <div class="hero-badge">{{site.heroSnippetCount}}</div>
     <h1>{{site.tagline_line1}}<br><span class="gradient">{{site.tagline_line2}}</span></h1>
     <p>{{site.description}}</p>
+    <div class="hero-actions">
+      <a href="/agent-plugin.html" class="primary-action">Get the agent plugin <span aria-hidden="true">→</span></a>
+      <a href="#all-comparisons" class="secondary-action">Browse patterns</a>
+    </div>
     <a href="{{homeUrl}}language/records-for-data-classes.html" class="hero-compare">
       <div class="hero-compare-side old">
         <div class="compare-label old">✕ {{site.heroOld}}</div>


### PR DESCRIPTION
Java developers need modernization advice that respects the project's actual compilation target instead of assuming the locally installed JDK. This adds a portable Agent Plugins 1.0 package that detects the effective Java version before recommending language features, APIs, or practices.

## What changed

- Adds the `modern-java-development` plugin with a portable Agent Skill, core guidance, and cumulative release guidance from Java 8 through Java 25.
- Detects project targets from explicit overrides, Maven, Gradle, toolchains, version-manager files, CI, environment, and runtime evidence, while reporting conflicts and keeping preview features opt-in.
- Includes focused detector tests for precedence, normalization, toolchains, and multi-module ambiguity.
- Adds a generated `/agent-plugin.html` landing page covering features, usage, and installation, plus homepage navigation and hero entry points.
- Keeps the plugin page canonical in English and prevents locale auto-redirects to nonexistent localized routes.

## Validation

- Generated all site locales with `jbang html-generators/generate.java`.
- Ran the detector unit tests.
- Checked the landing page at desktop and 390px mobile widths with no horizontal overflow.