### PR TITLE
Document agent plugin installation

### DIFF
--- a/agent-plugins/modern-java-development/README.md
+++ b/agent-plugins/modern-java-development/README.md
@@ -24,10 +24,66 @@ modern-java-development/
             └── test_detect_java_version.py
 ```
 
+## Install
+
+### GitHub Copilot CLI
+
+GitHub Copilot CLI supports the Agent Plugins specification, so it can install
+the complete package directly from this repository:
+
+```bash
+copilot plugin install javaevolved/javaevolved.github.io:agent-plugins/modern-java-development
+```
+
+To install a local checkout instead, pass its plugin directory:
+
+```bash
+copilot plugin install /absolute/path/to/agent-plugins/modern-java-development
+```
+
+See the
+[GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference)
+for other sources and marketplace installation.
+
+### Claude Code
+
+Claude Code supports the Agent Skills format used by the `modern-java` skill.
+Clone this repository and copy the skill to your personal skills directory:
+
+```bash
+git clone --depth 1 https://github.com/javaevolved/javaevolved.github.io.git
+mkdir -p ~/.claude/skills
+cp -R javaevolved.github.io/agent-plugins/modern-java-development/skills/modern-java \
+  ~/.claude/skills/
+```
+
+For a project-only installation, copy the skill to
+`.claude/skills/modern-java` in that project instead. See the
+[Claude Code skills documentation](https://code.claude.com/docs/en/skills).
+
+### OpenAI Codex CLI
+
+Codex CLI also supports Agent Skills. Clone this repository and copy the skill
+to your personal skills directory:
+
+```bash
+git clone --depth 1 https://github.com/javaevolved/javaevolved.github.io.git
+mkdir -p ~/.agents/skills
+cp -R javaevolved.github.io/agent-plugins/modern-java-development/skills/modern-java \
+  ~/.agents/skills/
+```
+
+For a project-only installation, copy the skill to
+`.agents/skills/modern-java` in that project instead. See the
+[Codex skills documentation](https://developers.openai.com/codex/skills/).
+
+Claude Code and Codex CLI use their own product-specific plugin manifests, so
+the instructions above install the portable skill rather than the root
+Agent Plugins manifest.
+
 ## Use
 
-Install or copy this directory into any Agent Plugins-compatible client. When
-the skill is active, the agent runs the detector from the Java project root:
+When the skill is active, the agent runs the detector from the Java project root:
 
 ```bash
 python3 skills/modern-java/scripts/detect_java_version.py .

--- a/site/styles.css
+++ b/site/styles.css
@@ -1809,9 +1809,6 @@ footer a:hover {
 }
 
 .plugin-install {
-  display: grid;
-  grid-template-columns: 0.9fr 1.1fr;
-  gap: 56px;
   max-width: 1052px;
   margin-top: 48px;
   margin-bottom: 96px;
@@ -1824,41 +1821,81 @@ footer a:hover {
 .plugin-install h2 { font-size: clamp(2rem, 4vw, 3rem); }
 
 .plugin-install p {
-  margin-top: 18px;
   color: #fff7ed;
+}
+
+.install-intro {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 56px;
+  align-items: end;
+  padding-bottom: 40px;
+  border-bottom: 1px solid rgba(255, 247, 237, 0.3);
+}
+
+.install-intro p {
+  max-width: 60ch;
+  font-size: 1.05rem;
+}
+
+.install-intro code,
+.install-scope code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.9em;
+}
+
+.install-options {
+  display: grid;
+}
+
+.install-option {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.65fr) minmax(0, 1.35fr);
+  gap: 10px 40px;
+  padding: 32px 0;
+  border-bottom: 1px solid rgba(255, 247, 237, 0.3);
+}
+
+.install-option:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.install-option h3 {
+  margin-bottom: 8px;
+  font-size: 1.15rem;
+}
+
+.install-option > div {
+  grid-row: 1 / span 4;
+}
+
+.install-option > div p,
+.install-option .install-scope {
+  color: #fed7aa;
+  font-size: 0.88rem;
+}
+
+.install-option > code {
+  display: block;
+  overflow-x: auto;
+  padding: 12px 14px;
+  border-radius: 6px;
+  background: #101117;
+  color: #fb923c;
+  font: 0.78rem/1.55 'JetBrains Mono', monospace;
+  white-space: nowrap;
 }
 
 .plugin-install a {
   display: inline-block;
-  margin-top: 24px;
+  justify-self: start;
+  margin-top: 4px;
+  color: #fff;
+  font-size: 0.84rem;
   font-weight: 750;
   text-decoration: underline;
   text-underline-offset: 4px;
-}
-
-.install-command {
-  align-self: center;
-  min-width: 0;
-  padding: 24px;
-  border-radius: var(--radius-sm);
-  background: #101117;
-  color: #d9d9e2;
-  box-shadow: 12px 16px 36px rgba(124, 45, 18, 0.3);
-}
-
-.install-command code {
-  display: block;
-  overflow-x: auto;
-  color: #fb923c;
-  font-size: 0.8rem;
-  white-space: nowrap;
-}
-
-.install-command p {
-  margin: 22px 0 8px;
-  color: #7d7f8d;
-  font: 0.72rem 'JetBrains Mono', monospace;
-  text-transform: uppercase;
 }
 
 /* ---------- Responsive: ≤ 700px ---------- */
@@ -1925,7 +1962,8 @@ footer a:hover {
   }
 
   .evidence-flow,
-  .plugin-install {
+  .install-intro,
+  .install-option {
     grid-template-columns: 1fr;
   }
 
@@ -1954,6 +1992,18 @@ footer a:hover {
     width: calc(100% - 32px);
     margin: 24px 16px 72px;
     padding: 36px 24px;
+  }
+
+  .install-intro {
+    gap: 16px;
+  }
+
+  .install-option {
+    gap: 12px;
+  }
+
+  .install-option > div {
+    grid-row: auto;
   }
 }
 

--- a/templates/agent-plugin.html
+++ b/templates/agent-plugin.html
@@ -144,15 +144,39 @@
     </section>
 
     <section class="plugin-install" id="install" aria-labelledby="install-title">
-      <div>
-        <h2 id="install-title">Install once. Keep the advice honest.</h2>
-        <p>Clone the repository, then register the plugin directory with any Agent Plugins-compatible client. Installation and enablement are controlled by each client.</p>
-        <a href="https://agent-plugins.org/plugin-authors/build-an-agent-plugin" target="_blank" rel="noopener">Read the Agent Plugins specification <span aria-hidden="true">↗</span></a>
+      <div class="install-intro">
+        <h2 id="install-title">Install it in your agent.</h2>
+        <p>Copilot CLI supports the complete Agent Plugins package. Claude Code and Codex CLI use the portable <code>modern-java</code> skill included in the package.</p>
       </div>
-      <div class="install-command">
-        <code>git clone https://github.com/javaevolved/javaevolved.github.io.git</code>
-        <p>Plugin path</p>
-        <code>agent-plugins/modern-java-development</code>
+      <div class="install-options">
+        <article class="install-option">
+          <div>
+            <h3>GitHub Copilot CLI</h3>
+            <p>Install the plugin directly from this repository.</p>
+          </div>
+          <code>copilot plugin install javaevolved/javaevolved.github.io:agent-plugins/modern-java-development</code>
+          <a href="https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference" target="_blank" rel="noopener">Copilot plugin documentation <span aria-hidden="true">↗</span></a>
+        </article>
+        <article class="install-option">
+          <div>
+            <h3>Claude Code</h3>
+            <p>Clone the repository, then install the skill for your user account.</p>
+          </div>
+          <code>git clone --depth 1 https://github.com/javaevolved/javaevolved.github.io.git</code>
+          <code>mkdir -p ~/.claude/skills &amp;&amp; cp -R javaevolved.github.io/agent-plugins/modern-java-development/skills/modern-java ~/.claude/skills/</code>
+          <p class="install-scope">For one project, copy it to <code>.claude/skills/modern-java</code> instead.</p>
+          <a href="https://code.claude.com/docs/en/skills" target="_blank" rel="noopener">Claude Code skill documentation <span aria-hidden="true">↗</span></a>
+        </article>
+        <article class="install-option">
+          <div>
+            <h3>OpenAI Codex CLI</h3>
+            <p>Clone the repository, then install the skill for your user account.</p>
+          </div>
+          <code>git clone --depth 1 https://github.com/javaevolved/javaevolved.github.io.git</code>
+          <code>mkdir -p ~/.agents/skills &amp;&amp; cp -R javaevolved.github.io/agent-plugins/modern-java-development/skills/modern-java ~/.agents/skills/</code>
+          <p class="install-scope">For one project, copy it to <code>.agents/skills/modern-java</code> instead.</p>
+          <a href="https://developers.openai.com/codex/skills/" target="_blank" rel="noopener">Codex skill documentation <span aria-hidden="true">↗</span></a>
+        </article>
       </div>
     </section>
   </main>


### PR DESCRIPTION
The new agent plugin page did not explain how to install the plugin in supported coding agents, leaving users to translate the portable package into each product's installation model.

This adds official, linked installation instructions for GitHub Copilot CLI, Claude Code, and OpenAI Codex CLI to both the website and the plugin README. Copilot installs the complete Agent Plugins package directly, while Claude Code and Codex install the bundled portable Agent Skill through their documented user or project skill directories. The page's installation section is also reworked into a responsive, platform-by-platform layout.

The static site generator completes successfully with the updated template.