### PR TITLE
Use marketplace flow for Copilot plugin installation

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "javaevolved",
+  "owner": {
+    "name": "java.evolved"
+  },
+  "metadata": {
+    "description": "Version-aware tools for modern Java development.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "modern-java-development",
+      "description": "Version-aware guidance for writing, reviewing, and modernizing Java projects.",
+      "version": "1.0.0",
+      "source": "./agent-plugins/modern-java-development",
+      "category": "development"
+    }
+  ]
+}

--- a/agent-plugins/modern-java-development/README.md
+++ b/agent-plugins/modern-java-development/README.md
@@ -28,22 +28,22 @@ modern-java-development/
 
 ### GitHub Copilot CLI
 
-GitHub Copilot CLI supports the Agent Plugins specification, so it can install
-the complete package directly from this repository:
+GitHub Copilot CLI supports the Agent Plugins specification. Add the
+java.evolved marketplace once:
 
 ```bash
-copilot plugin install javaevolved/javaevolved.github.io:agent-plugins/modern-java-development
+copilot plugin marketplace add javaevolved/javaevolved.github.io
 ```
 
-To install a local checkout instead, pass its plugin directory:
+Then install the plugin:
 
 ```bash
-copilot plugin install /absolute/path/to/agent-plugins/modern-java-development
+copilot plugin install modern-java-development@javaevolved
 ```
 
 See the
 [GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference)
-for other sources and marketplace installation.
+for marketplace management and plugin updates.
 
 ### Claude Code
 

--- a/templates/agent-plugin.html
+++ b/templates/agent-plugin.html
@@ -152,9 +152,10 @@
         <article class="install-option">
           <div>
             <h3>GitHub Copilot CLI</h3>
-            <p>Install the plugin directly from this repository.</p>
+            <p>Add the java.evolved marketplace once, then install the plugin.</p>
           </div>
-          <code>copilot plugin install javaevolved/javaevolved.github.io:agent-plugins/modern-java-development</code>
+          <code>copilot plugin marketplace add javaevolved/javaevolved.github.io</code>
+          <code>copilot plugin install modern-java-development@javaevolved</code>
           <a href="https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference" target="_blank" rel="noopener">Copilot plugin documentation <span aria-hidden="true">↗</span></a>
         </article>
         <article class="install-option">


### PR DESCRIPTION
Direct repository plugin installs are deprecated and now emit a warning in Copilot CLI. This change makes the modern Java plugin available through a repository marketplace and updates the published instructions to use the supported installation flow.

The repository now exposes a `javaevolved` marketplace manifest. Users register it once, then install `modern-java-development@javaevolved`; the plugin README and generated installation page show the same commands.