### PR TITLE
Polish agent installation commands

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -445,24 +445,32 @@
      4. Copy-to-Clipboard (article pages)
      ========================================================== */
   const initCopyButtons = () => {
-    document.querySelectorAll('.copy-btn').forEach(btn => {
+    document.querySelectorAll('.copy-btn, .command-copy-btn').forEach(btn => {
       btn.addEventListener('click', () => {
-        // Find adjacent code block
-        const codeBlock = btn.closest('.code-header')?.nextElementSibling
+        const codeBlock = btn.closest('.install-command')?.querySelector('code')
+          || btn.closest('.code-header')?.nextElementSibling
           || btn.closest('.compare-panel-header')?.nextElementSibling?.querySelector('pre, code, .code-text')
           || btn.parentElement?.querySelector('pre, code, .code-text');
         if (!codeBlock) return;
 
         const text = codeBlock.textContent;
-        navigator.clipboard.writeText(text).then(() => {
+        const originalContent = btn.innerHTML;
+        const originalLabel = btn.getAttribute('aria-label');
+        const showCopied = () => {
           btn.classList.add('copied');
-          const original = btn.textContent;
-          btn.textContent = (window.i18n && window.i18n.copied) || 'Copied!';
+          if (btn.classList.contains('command-copy-btn')) {
+            btn.innerHTML = '<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="m3 8.25 3 3 7-7" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+            btn.setAttribute('aria-label', 'Command copied');
+          } else {
+            btn.textContent = (window.i18n && window.i18n.copied) || 'Copied!';
+          }
           setTimeout(() => {
             btn.classList.remove('copied');
-            btn.textContent = original;
+            btn.innerHTML = originalContent;
+            if (originalLabel) btn.setAttribute('aria-label', originalLabel);
           }, 2000);
-        }).catch(() => {
+        };
+        const fallbackCopy = () => {
           // Fallback for older browsers
           const textarea = document.createElement('textarea');
           textarea.value = text;
@@ -472,14 +480,14 @@
           textarea.select();
           document.execCommand('copy');
           document.body.removeChild(textarea);
-          btn.classList.add('copied');
-          const original = btn.textContent;
-          btn.textContent = (window.i18n && window.i18n.copied) || 'Copied!';
-          setTimeout(() => {
-            btn.classList.remove('copied');
-            btn.textContent = original;
-          }, 2000);
-        });
+          showCopied();
+        };
+
+        if (navigator.clipboard && window.isSecureContext) {
+          navigator.clipboard.writeText(text).then(showCopied).catch(fallbackCopy);
+        } else {
+          fallbackCopy();
+        }
       });
     });
   };

--- a/site/styles.css
+++ b/site/styles.css
@@ -1851,8 +1851,8 @@ footer a:hover {
 .install-option {
   display: grid;
   grid-template-columns: minmax(180px, 0.65fr) minmax(0, 1.35fr);
-  gap: 10px 40px;
-  padding: 32px 0;
+  gap: 14px 48px;
+  padding: 36px 0;
   border-bottom: 1px solid rgba(255, 247, 237, 0.3);
 }
 
@@ -1866,25 +1866,61 @@ footer a:hover {
   font-size: 1.15rem;
 }
 
-.install-option > div {
+.install-option-copy {
   grid-row: 1 / span 4;
 }
 
-.install-option > div p,
+.install-option-copy p,
 .install-option .install-scope {
   color: #fed7aa;
   font-size: 0.88rem;
 }
 
-.install-option > code {
-  display: block;
-  overflow-x: auto;
-  padding: 12px 14px;
-  border-radius: 6px;
+.install-command {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 44px;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid #2f3039;
+  border-radius: 8px;
   background: #101117;
+}
+
+.install-command code {
+  display: block;
+  min-width: 0;
+  overflow-x: auto;
+  padding: 15px 18px;
   color: #fb923c;
   font: 0.78rem/1.55 'JetBrains Mono', monospace;
   white-space: nowrap;
+  scrollbar-color: #52525b transparent;
+  scrollbar-width: thin;
+}
+
+.command-copy-btn {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  min-height: 44px;
+  border-left: 1px solid #2f3039;
+  background: #191a21;
+  color: #a1a1aa;
+  transition: background 0.15s, color 0.15s;
+}
+
+.command-copy-btn:hover {
+  background: #24252d;
+  color: #fff;
+}
+
+.command-copy-btn:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: -4px;
+}
+
+.command-copy-btn.copied {
+  color: #34d399;
 }
 
 .plugin-install a {
@@ -2002,7 +2038,7 @@ footer a:hover {
     gap: 12px;
   }
 
-  .install-option > div {
+  .install-option-copy {
     grid-row: auto;
   }
 }

--- a/templates/agent-plugin.html
+++ b/templates/agent-plugin.html
@@ -150,31 +150,61 @@
       </div>
       <div class="install-options">
         <article class="install-option">
-          <div>
-            <h3>GitHub Copilot CLI</h3>
+          <div class="install-option-copy">
+            <h3>GitHub Copilot</h3>
             <p>Add the java.evolved marketplace once, then install the plugin.</p>
           </div>
-          <code>copilot plugin marketplace add javaevolved/javaevolved.github.io</code>
-          <code>copilot plugin install modern-java-development@javaevolved</code>
+          <div class="install-command">
+            <code>copilot plugin marketplace add javaevolved/javaevolved.github.io</code>
+            <button class="command-copy-btn" type="button" aria-label="Copy command">
+              <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M5.75 1.5h6.75a2 2 0 0 1 2 2v6.75a2 2 0 0 1-2 2h-1V9.5a5 5 0 0 0-5-5H3.5v-1a2 2 0 0 1 2-2h.25Zm-2.25 4h3a4 4 0 0 1 4 4v3a2 2 0 0 1-2 2h-5a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2Z" fill="currentColor"/></svg>
+            </button>
+          </div>
+          <div class="install-command">
+            <code>copilot plugin install modern-java-development@javaevolved</code>
+            <button class="command-copy-btn" type="button" aria-label="Copy command">
+              <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M5.75 1.5h6.75a2 2 0 0 1 2 2v6.75a2 2 0 0 1-2 2h-1V9.5a5 5 0 0 0-5-5H3.5v-1a2 2 0 0 1 2-2h.25Zm-2.25 4h3a4 4 0 0 1 4 4v3a2 2 0 0 1-2 2h-5a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2Z" fill="currentColor"/></svg>
+            </button>
+          </div>
           <a href="https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference" target="_blank" rel="noopener">Copilot plugin documentation <span aria-hidden="true">↗</span></a>
         </article>
         <article class="install-option">
-          <div>
+          <div class="install-option-copy">
             <h3>Claude Code</h3>
             <p>Clone the repository, then install the skill for your user account.</p>
           </div>
-          <code>git clone --depth 1 https://github.com/javaevolved/javaevolved.github.io.git</code>
-          <code>mkdir -p ~/.claude/skills &amp;&amp; cp -R javaevolved.github.io/agent-plugins/modern-java-development/skills/modern-java ~/.claude/skills/</code>
+          <div class="install-command">
+            <code>git clone --depth 1 https://github.com/javaevolved/javaevolved.github.io.git</code>
+            <button class="command-copy-btn" type="button" aria-label="Copy command">
+              <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M5.75 1.5h6.75a2 2 0 0 1 2 2v6.75a2 2 0 0 1-2 2h-1V9.5a5 5 0 0 0-5-5H3.5v-1a2 2 0 0 1 2-2h.25Zm-2.25 4h3a4 4 0 0 1 4 4v3a2 2 0 0 1-2 2h-5a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2Z" fill="currentColor"/></svg>
+            </button>
+          </div>
+          <div class="install-command">
+            <code>mkdir -p ~/.claude/skills &amp;&amp; cp -R javaevolved.github.io/agent-plugins/modern-java-development/skills/modern-java ~/.claude/skills/</code>
+            <button class="command-copy-btn" type="button" aria-label="Copy command">
+              <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M5.75 1.5h6.75a2 2 0 0 1 2 2v6.75a2 2 0 0 1-2 2h-1V9.5a5 5 0 0 0-5-5H3.5v-1a2 2 0 0 1 2-2h.25Zm-2.25 4h3a4 4 0 0 1 4 4v3a2 2 0 0 1-2 2h-5a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2Z" fill="currentColor"/></svg>
+            </button>
+          </div>
           <p class="install-scope">For one project, copy it to <code>.claude/skills/modern-java</code> instead.</p>
           <a href="https://code.claude.com/docs/en/skills" target="_blank" rel="noopener">Claude Code skill documentation <span aria-hidden="true">↗</span></a>
         </article>
         <article class="install-option">
-          <div>
+          <div class="install-option-copy">
             <h3>OpenAI Codex CLI</h3>
             <p>Clone the repository, then install the skill for your user account.</p>
           </div>
-          <code>git clone --depth 1 https://github.com/javaevolved/javaevolved.github.io.git</code>
-          <code>mkdir -p ~/.agents/skills &amp;&amp; cp -R javaevolved.github.io/agent-plugins/modern-java-development/skills/modern-java ~/.agents/skills/</code>
+          <div class="install-command">
+            <code>git clone --depth 1 https://github.com/javaevolved/javaevolved.github.io.git</code>
+            <button class="command-copy-btn" type="button" aria-label="Copy command">
+              <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M5.75 1.5h6.75a2 2 0 0 1 2 2v6.75a2 2 0 0 1-2 2h-1V9.5a5 5 0 0 0-5-5H3.5v-1a2 2 0 0 1 2-2h.25Zm-2.25 4h3a4 4 0 0 1 4 4v3a2 2 0 0 1-2 2h-5a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2Z" fill="currentColor"/></svg>
+            </button>
+          </div>
+          <div class="install-command">
+            <code>mkdir -p ~/.agents/skills &amp;&amp; cp -R javaevolved.github.io/agent-plugins/modern-java-development/skills/modern-java ~/.agents/skills/</code>
+            <button class="command-copy-btn" type="button" aria-label="Copy command">
+              <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path d="M5.75 1.5h6.75a2 2 0 0 1 2 2v6.75a2 2 0 0 1-2 2h-1V9.5a5 5 0 0 0-5-5H3.5v-1a2 2 0 0 1 2-2h.25Zm-2.25 4h3a4 4 0 0 1 4 4v3a2 2 0 0 1-2 2h-5a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2Z" fill="currentColor"/></svg>
+            </button>
+          </div>
           <p class="install-scope">For one project, copy it to <code>.agents/skills/modern-java</code> instead.</p>
           <a href="https://developers.openai.com/codex/skills/" target="_blank" rel="noopener">Codex skill documentation <span aria-hidden="true">↗</span></a>
         </article>


### PR DESCRIPTION
The agent installation section needs clearer command actions and enough room for long installation paths, especially the Codex example.

- Add accessible copy buttons to every installation command with visual copied-state feedback and a clipboard fallback.
- Keep long commands scrollable while the copy control remains fixed and visible.
- Increase spacing within the installation options and correct responsive grid behavior.
- Shorten the product label from "GitHub Copilot CLI" to "GitHub Copilot".