### PR TITLE
Expand modern Java agent plugin guidance

### DIFF
--- a/.github/workflows/release-agent-plugin.yml
+++ b/.github/workflows/release-agent-plugin.yml
@@ -102,7 +102,8 @@ jobs:
         working-directory: agent-plugins/modern-java-development
         run: |
           python3 -m unittest \
-            skills/modern-java/scripts/test_detect_java_version.py
+            skills/modern-java/scripts/test_detect_java_version.py \
+            skills/modern-java/scripts/test_reference_coverage.py
           jq --exit-status \
             --arg version "${{ steps.version.outputs.version }}" \
             '.version == $version' plugin.json >/dev/null

--- a/agent-plugins/modern-java-development/README.md
+++ b/agent-plugins/modern-java-development/README.md
@@ -18,9 +18,11 @@ modern-java-development/
         ├── SKILL.md
         ├── references/
         │   ├── core-practices.md
+        │   ├── enterprise-practices.md
         │   └── release-practices.md
         └── scripts/
             ├── detect_java_version.py
+            ├── test_reference_coverage.py
             └── test_detect_java_version.py
 ```
 
@@ -106,7 +108,8 @@ lower-confidence runtime evidence and report conflicting build configuration.
 
 ```bash
 python3 -m unittest \
-  skills/modern-java/scripts/test_detect_java_version.py
+  skills/modern-java/scripts/test_detect_java_version.py \
+  skills/modern-java/scripts/test_reference_coverage.py
 ```
 
 ## Release

--- a/agent-plugins/modern-java-development/skills/modern-java/SKILL.md
+++ b/agent-plugins/modern-java-development/skills/modern-java/SKILL.md
@@ -39,6 +39,10 @@ features or APIs the build accepts.
    release and all earlier applicable groups in
    [release practices](references/release-practices.md). Recommendations are
    cumulative: Java 21 code may use final features from Java 21 and below.
+   When Jakarta EE, MicroProfile, Spring, JPA, JDBC, jOOQ, JSF, JAX-RS, JMS,
+   EJB, or CDI is in scope, also read
+   [enterprise practices](references/enterprise-practices.md). Framework
+   versions are a separate compatibility axis from the Java target.
 
 4. Inspect whether preview is explicitly enabled (`--enable-preview` in both
    compile and runtime/test configuration). Do not recommend preview features
@@ -54,6 +58,9 @@ features or APIs the build accepts.
      maintainer's local JDK.
    - **Multi-release or multi-module builds:** evaluate each affected source set
      or module against its own target.
+   - **Framework migrations:** verify the framework/runtime version, namespace
+     (`javax.*` versus `jakarta.*`), deployment model, and operational semantics.
+     Do not infer framework capability from the Java target alone.
 
 6. Validate with the project's existing build using its configured toolchain.
    Compile and run tests with the same `--release` and preview settings used by

--- a/agent-plugins/modern-java-development/skills/modern-java/references/enterprise-practices.md
+++ b/agent-plugins/modern-java-development/skills/modern-java/references/enterprise-practices.md
@@ -1,0 +1,101 @@
+# Enterprise Java and framework practices
+
+Apply this guide only when the corresponding framework is present. The Java
+compilation target, Jakarta EE platform level, MicroProfile version, Spring
+generation, provider capabilities, and database support are independent
+compatibility axes. Detect each from build dependencies and deployment
+configuration before recommending a migration.
+
+## Migration boundaries
+
+- Preserve transaction boundaries, security constraints, retries, delivery
+  guarantees, persistence behavior, observability, and container lifecycle.
+  Replacing annotations is not proof of equivalent behavior.
+- Treat `javax.*` to `jakarta.*` as an ecosystem migration. Verify the runtime,
+  dependencies, generated sources, descriptors, tests, and integrations move
+  together; do not mix the namespaces in one application.
+- Prefer constructor injection for required dependencies when the framework
+  supports it. Use field or resource injection only where the container contract
+  requires it.
+- Confirm native-image/AOT, reflection, proxying, serialization, and build-time
+  indexing constraints before changing frameworks or component models.
+
+## Jakarta component model
+
+- Prefer CDI scopes and `@Inject` for ordinary application services over EJB
+  session beans, and use `@Transactional` when its interceptor semantics match.
+  Keep EJB where remote interfaces, passivation, asynchronous methods, timers,
+  pooling, or other EJB services are required.
+  <!-- covers: ejb-vs-cdi singleton-ejb-vs-cdi-application-scoped -->
+- Replace JNDI service-locator code with typed injection for managed resources,
+  but retain explicit lookup at genuine dynamic naming boundaries.
+  <!-- covers: jndi-lookup-vs-cdi-injection -->
+- Prefer CDI `@Named` beans to legacy JSF managed beans. Verify scopes, proxy
+  requirements, serialization, and view lifetime during migration.
+  <!-- covers: jsf-managed-bean-vs-cdi-named -->
+- Prefer declarative `@Transactional` boundaries at service methods over manual
+  transaction choreography. Keep explicit transactions when one method truly
+  needs multiple independently controlled units of work, and account for
+  self-invocation and rollback rules.
+  <!-- covers: manual-transaction-vs-declarative -->
+- Use Jakarta Concurrency managed executors rather than application-created
+  threads in a Jakarta runtime. Do not replace persistent, calendar-based EJB
+  timers with an in-memory fixed-rate schedule unless restart, clustering,
+  misfire, timezone, and exactly-once requirements permit it.
+  <!-- covers: ejb-timer-vs-jakarta-scheduler -->
+
+## HTTP APIs and messaging
+
+- Prefer Jakarta REST resources for resource-oriented HTTP APIs over low-level
+  servlet dispatch code. Keep filters, streaming, protocol upgrades, and other
+  servlet-level behavior where those APIs are the right abstraction.
+  <!-- covers: servlet-vs-jaxrs -->
+- Prefer REST/JSON over SOAP only when contracts, WS-Security, reliable
+  messaging, transactions, schema-first tooling, and client compatibility do
+  not require the WS-* stack. Modernize the contract, not merely the transport.
+  <!-- covers: soap-vs-jakarta-rest -->
+- Consider MicroProfile Reactive Messaging for channel-based event processing,
+  typed payloads, and backpressure. Before replacing an MDB, match JMS
+  acknowledgement, ordering, redelivery, dead-letter, transaction, selector,
+  and concurrency semantics and verify the chosen connector.
+  <!-- covers: mdb-vs-reactive-messaging -->
+
+## Persistence choices
+
+- Use JPA for aggregate-oriented persistence and managed entity lifecycles; use
+  JDBC when exact SQL, low overhead, bulk operations, or database-specific
+  control is more important. Account for lazy loading, fetching, locking,
+  batching, caching, and transaction scope rather than assuming ORM is simpler.
+  <!-- covers: jdbc-vs-jpa -->
+- Use the JPA Criteria API for genuinely dynamic entity queries. It is not fully
+  type-safe when attributes are referenced by strings; use the static metamodel
+  or another typed query approach when compile-time attribute checking matters.
+  <!-- covers: jdbc-resultset-vs-jpa-criteria -->
+- Consider jOOQ when SQL is the primary abstraction and generated schema types,
+  CTEs, window functions, vendor features, and composable queries matter.
+  Verify edition/database support, code generation, dialect behavior, and
+  transaction integration. Continue binding all untrusted values.
+  <!-- covers: jdbc-vs-jooq -->
+- Prefer Jakarta Data repositories for conventional CRUD and derived queries
+  when the Jakarta EE 11 runtime and provider implement the required behavior.
+  Retain `EntityManager`, criteria, or SQL for complex persistence operations,
+  and verify query derivation, pagination, locking, and transaction semantics.
+  <!-- covers: jpa-vs-jakarta-data -->
+
+## Spring
+
+- Prefer annotation-based configuration, constructor injection, and focused
+  explicit `@Configuration` over large XML bean graphs in modern Spring.
+  Preserve XML where externalized wiring or legacy integration makes it useful;
+  do not rely on broad component scanning that obscures ownership.
+  <!-- covers: spring-xml-config-vs-annotations -->
+- On Spring Framework 7, use native API version conditions when they match the
+  public versioning strategy. Keep version negotiation centralized, document
+  deprecation and compatibility policy, and avoid merging unrelated versions
+  into a controller merely to reduce class count.
+  <!-- covers: spring-api-versioning -->
+- On Spring Framework 7, migrate Spring nullness annotations to JSpecify
+  deliberately. Establish `@NullMarked` boundaries, annotate type uses
+  accurately, configure a checker, and treat diagnostics as migration work
+  rather than suppressing them.
+  <!-- covers: spring-null-safety-jspecify -->

--- a/agent-plugins/modern-java-development/skills/modern-java/references/release-practices.md
+++ b/agent-plugins/modern-java-development/skills/modern-java/references/release-practices.md
@@ -1,28 +1,73 @@
 # Practices by final Java release
 
-Use the group matching the detected target plus all earlier groups. These are
-capabilities that became final in that release; preview history is intentionally
-excluded. Empty releases are grouped with adjacent releases.
+Use the group matching the detected target plus all earlier groups. The entries
+name capabilities that became final in that release unless explicitly labeled
+preview. Preview history is otherwise excluded. API availability still depends
+on the exact runtime and module graph.
+
+## Java 7 and older maintenance targets
+
+- Use multi-catch when handlers have identical behavior and neither alternative
+  needs a more specific type. Preserve separate catches when recovery differs.
+  <!-- covers: multi-catch -->
+- This guide does not recommend new development on pre-Java 8 targets. Preserve
+  compatibility, apply general engineering practices, and plan a supported-JDK
+  migration separately from behavior-preserving refactoring.
 
 ## Java 8 baseline
 
-- Use lambdas and method references when they clarify behavior.
-- Use streams for side-effect-free collection transformations and reductions.
-- Use `java.time` instead of `Date`, `Calendar`, and `SimpleDateFormat`.
-- Use `CompletableFuture` for genuinely asynchronous composition, not as a
-  wrapper around blocking code without an executor strategy.
-- Use default and static interface methods deliberately to evolve APIs.
+- Use lambdas and method references when they clarify behavior, and streams for
+  side-effect-free transformations and reductions. Use
+  `stream.toArray(Type[]::new)` when a typed array is the required API boundary.
+  <!-- covers: stream-toarray-typed -->
+- Use `java.time`, `DateTimeFormatter`, `Duration`, and `Period` instead of
+  mutable `Date`, `Calendar`, `SimpleDateFormat`, or unitless millisecond math.
+  <!-- covers: java-time-basics date-formatting duration-and-period -->
+- Use `CompletableFuture` for genuinely asynchronous composition, with an
+  explicit executor and failure strategy; do not block each stage with `get`.
+  <!-- covers: completablefuture-chaining -->
+- Use default methods to evolve interfaces compatibly and static interface
+  methods for operations conceptually owned by that API. Avoid turning an
+  interface into an unrelated utility namespace.
+  <!-- covers: default-interface-methods static-methods-in-interfaces -->
 
 ## Java 9
 
 - Prefer `List.of`, `Set.of`, `Map.of`, and `Map.entry` for small immutable
-  collections; reject nulls intentionally.
-- Use `takeWhile`, `dropWhile`, `Stream.ofNullable`, `Optional.or`, and
-  `ifPresentOrElse` where they directly express intent.
-- Use private interface methods to share implementation among defaults.
-- Use `InputStream.transferTo`, effectively-final resources in
-  try-with-resources, `ProcessHandle`, and the JDK HTTP/2 client incubator only
-  with awareness that the standardized HTTP Client arrives in Java 11.
+  collections. They reject nulls, and duplicate set elements/map keys fail.
+  <!-- covers: immutable-list-creation immutable-set-creation immutable-map-creation map-entry-factory -->
+- Use `takeWhile`/`dropWhile` only with understood encounter-order semantics;
+  use `Stream.ofNullable`, three-argument `iterate`, `Collectors.flatMapping`,
+  `Optional.or`, and `ifPresentOrElse` when they directly express intent.
+  <!-- covers: stream-takewhile-dropwhile stream-of-nullable stream-iterate-predicate collectors-flatmapping optional-or optional-ifpresentorelse optional-chaining -->
+- Use `Objects.requireNonNullElse` for a non-null eager default; use the supplier
+  variant when fallback construction is expensive.
+  <!-- covers: require-nonnull-else -->
+- Use private interface methods to share implementation among defaults, and the
+  diamond operator with anonymous classes when inference remains obvious.
+  <!-- covers: private-interface-methods diamond-operator -->
+- Use `InputStream.transferTo` for whole-stream copying and effectively-final
+  resources in try-with-resources when ownership and close timing are clear.
+  <!-- covers: inputstream-transferto try-with-resources-effectively-final -->
+- Use `ProcessBuilder` to start processes and `ProcessHandle` to inspect or
+  manage them. Drain output, bound waits, and handle process-tree termination.
+  <!-- covers: process-api -->
+- Preserve nanosecond `Instant` precision through storage and serialization;
+  do not silently truncate to epoch milliseconds.
+  <!-- covers: instant-precision -->
+- Avoid native Java serialization for untrusted data. Where legacy
+  deserialization remains, install narrow `ObjectInputFilter` limits.
+  <!-- covers: deserialization-filters -->
+- Use `SecureRandom.getInstanceStrong()` only when its potentially blocking
+  provider behavior is acceptable; ordinary `SecureRandom` is appropriate for
+  most security-sensitive generation.
+  <!-- covers: strong-random -->
+- Use `String.chars()` for UTF-16 code units and `codePoints()` for Unicode code
+  points; neither directly iterates grapheme clusters.
+  <!-- covers: string-chars-stream -->
+- Use JShell for exploration and JFR for low-overhead production diagnostics.
+  Record representative workloads and protect sensitive event data.
+  <!-- covers: jshell-prototyping jfr-profiling -->
 - Use modules only with an explicit encapsulation or distribution goal; do not
   modularize mechanically.
 
@@ -31,136 +76,230 @@ excluded. Empty releases are grouped with adjacent releases.
 - Use local `var` when the initializer makes the type obvious and the name
   preserves intent. Avoid it when it hides an important numeric, generic, or
   domain type.
-- Use `List.copyOf`, `Set.copyOf`, and `Map.copyOf` for immutable snapshots.
-- Use no-argument `Optional.orElseThrow()` for required values.
+  <!-- covers: type-inference-with-var -->
+- Use `List.copyOf`, `Set.copyOf`, and `Map.copyOf` for unmodifiable snapshots,
+  understanding that an already unmodifiable input may be reused.
+  <!-- covers: copying-collections-immutably -->
+- Use no-argument `Optional.orElseThrow()` for required values rather than
+  `get()`, unless a domain-specific exception provides better context.
+  <!-- covers: optional-orelsethrow -->
 
 ## Java 11
 
-- Prefer the standardized `java.net.http.HttpClient` for JDK-native HTTP,
-  configuring timeouts and handling interruption.
+- Prefer `java.net.http.HttpClient` for JDK-native HTTP. Reuse clients, configure
+  connect/request timeouts, handle interruption, and validate status and body
+  limits.
+  <!-- covers: http-client -->
 - Use `String.isBlank`, `strip`, `lines`, and `repeat` instead of hand-written
-  equivalents.
+  equivalents. `strip` is Unicode-aware; `lines` recognizes multiple line
+  terminators and does not retain them.
+  <!-- covers: string-isblank string-strip string-lines string-repeat -->
 - Use `Files.readString`, `writeString`, and `Path.of` for appropriately sized
-  content.
-- Use `Predicate.not` and `Optional.isEmpty` where they improve readability.
-- Run small single-file source programs directly when a full build is needless.
-- Rely on TLS 1.3 defaults where interoperability permits.
+  content with explicit charset/options where defaults are not the contract.
+  Do not load unbounded files wholly into memory.
+  <!-- covers: reading-files writing-files path-of -->
+- Use `Predicate.not` where it reads better than lambda negation.
+  <!-- covers: predicate-not -->
+- Run small single-file source programs directly when a build is needless;
+  retain a normal build for dependencies, repeatable testing, and packaging.
+  <!-- covers: single-file-execution -->
+- Rely on TLS 1.3 defaults where peers permit, while retaining hostname
+  verification, certificate validation, and explicit protocol policy when
+  interoperability requires it.
+  <!-- covers: tls-default -->
 
 ## Java 12-13
 
-- Use `Files.mismatch` to compare file content and `Collectors.teeing` for two
-  independent reductions over one stream.
-- Use `String.indent` and `transform` for explicit text pipelines.
-- Do not use switch expressions yet unless preview is intentionally enabled;
-  they become final in Java 14.
+- Use `Files.mismatch` for a mismatch position without hand-written byte loops.
+  <!-- covers: files-mismatch -->
+- Use `Collectors.teeing` for two independent reductions over one stream when it
+  is clearer than an explicit accumulator.
+  <!-- covers: collectors-teeing -->
+- Use `String.indent` and `transform` for explicit text pipelines, accounting
+  for line terminator normalization by `indent`.
+  <!-- covers: string-indent-transform -->
+- Do not use switch expressions on these targets unless preview is intentionally
+  enabled; they become final in Java 14.
 
 ## Java 14
 
-- Use switch expressions with `->` and `yield` for value-producing,
-  exhaustively handled decisions.
-- Use helpful NullPointerException diagnostics during development; still
-  validate public inputs with domain-specific messages.
+- Use switch expressions with `->` and `yield` for value-producing decisions.
+  Keep side-effect-heavy control flow as statements.
+  <!-- covers: switch-expressions -->
+- Use helpful NullPointerException diagnostics for diagnosis, but still validate
+  public inputs with domain-specific messages and do not parse VM messages.
+  <!-- covers: helpful-npe -->
 
 ## Java 15
 
-- Use text blocks for multiline SQL, JSON, HTML, and test fixtures while
-  reviewing incidental indentation and escaping.
-- Use `String.formatted` when receiver-oriented formatting reads more clearly
-  than `String.format`.
+- Use text blocks for multiline SQL, JSON, HTML, and fixtures while reviewing
+  incidental indentation, trailing whitespace, and escaping.
+  <!-- covers: text-blocks-for-multiline-strings -->
+- Use `String.formatted` when receiver-oriented formatting is clearer than
+  `String.format`; specify locale explicitly for locale-sensitive output.
+  <!-- covers: string-formatted -->
 
 ## Java 16
 
-- Use records for transparent, shallowly immutable data carriers. Defensively
-  copy mutable components in a compact canonical constructor.
-- Use pattern matching for `instanceof` to remove redundant casts.
-- Use `Stream.toList()` when an unmodifiable result is intended; do not assume
-  a particular implementation or null-rejection behavior.
+- Use records for transparent, shallowly immutable data carriers and compact
+  constructors for validation/normalization. Defensively copy mutable
+  components and consider serialization/framework contracts.
+  <!-- covers: records-for-data-classes compact-canonical-constructor record-based-errors -->
+- Use pattern matching for `instanceof` to remove redundant casts while keeping
+  variable scope narrow.
+  <!-- covers: pattern-matching-instanceof -->
+- Use `Stream.toList()` for an unmodifiable result; do not assume a concrete
+  implementation, null policy equivalent to `List.of`, or mutability equivalent
+  to `Collectors.toList`.
+  <!-- covers: stream-tolist unmodifiable-collectors -->
 - Use `mapMulti` when one input emits zero or more outputs without temporary
-  streams.
-- Use `toUnmodifiableList`, `Set`, or `Map` when collector semantics are needed.
+  streams and the callback remains readable.
+  <!-- covers: stream-mapmulti -->
+- Inner classes may declare static members. Use them only when the member belongs
+  to that nested type; do not use the relaxation to hide unrelated globals.
+  <!-- covers: static-members-in-inner-classes -->
 
 ## Java 17
 
-- Use sealed classes and interfaces for intentionally closed hierarchies,
-  especially when exhaustive handling is valuable.
-- Use `HexFormat` instead of custom hexadecimal conversion.
+- Use sealed classes/interfaces for intentionally closed hierarchies, especially
+  when exhaustive handling is valuable. Account for modules/packages, proxies,
+  persistence frameworks, and downstream extension points.
+  <!-- covers: sealed-classes -->
+- Use `HexFormat` instead of custom hexadecimal conversion and specify delimiter,
+  prefix, suffix, and case as part of the format contract.
+  <!-- covers: hex-format -->
 - Use the `RandomGenerator` hierarchy when algorithm selection or modern
   pseudo-random generators matter; continue using `SecureRandom` for security.
+  <!-- covers: random-generator -->
+- Java 17 is the minimum for JUnit 6. Adopt it only after checking engine,
+  extension, IDE, and build-tool compatibility; configure JSpecify-aware
+  nullness analysis rather than treating annotations as runtime validation.
+  <!-- covers: junit6-with-jspecify -->
 - Treat strong encapsulation of JDK internals as a migration requirement, not
   something to bypass permanently with `--add-opens`.
-- Java 17 is the minimum for JUnit 6; use JSpecify-aware nullness tooling when
-  adopting it.
 
 ## Java 18-20
 
-- Use the simple web server (`jwebserver`) for local static development, not as
-  a production application server.
-- Use `Thread.sleep(Duration)` and try-with-resources for `ExecutorService`
-  starting in Java 19.
-- Do not recommend record patterns, pattern-switch, or virtual threads as final
-  features before Java 21.
+- Use `jwebserver` for local static development and diagnostics, not as a
+  production application server.
+  <!-- covers: built-in-http-server -->
+- Use `Thread.sleep(Duration)` to make units explicit while preserving
+  interruption and avoiding sleeps as coordination.
+  <!-- covers: thread-sleep-duration -->
+- Use try-with-resources for locally owned `ExecutorService` lifetimes. Define
+  cancellation, graceful shutdown, timeout, and forced-shutdown behavior.
+  <!-- covers: executor-try-with-resources -->
+- Record patterns, pattern switch, and virtual threads are not final before Java
+  21.
 
 ## Java 21
 
 - Use virtual threads for high-throughput workloads dominated by blocking I/O.
-  Do not pool virtual threads, and audit pinning, `ThreadLocal` usage, native
-  calls, rate limits, and downstream capacity.
-- Use record patterns and final pattern matching for switch for concise,
-  exhaustive data-oriented logic.
-- Use sequenced collection APIs (`getFirst`, `getLast`, `reversed`) instead of
-  index arithmetic or copied reversals.
-- Use `Math.clamp` for bounded numeric values.
+  Do not pool them; audit pinning, `ThreadLocal` usage, native calls, rate limits,
+  observability, and downstream capacity. Prefer one task per virtual thread and
+  bound the scarce external resource rather than the thread count.
+  <!-- covers: virtual-threads virtual-thread-executor concurrent-http-virtual -->
+- Use record patterns and pattern matching for switch for concise data-oriented
+  logic. Use guards for case-specific predicates, `case null` only when null is
+  part of the input contract, and sealed exhaustiveness instead of a masking
+  `default` when all permitted cases should be handled.
+  <!-- covers: record-patterns pattern-matching-switch guarded-patterns null-in-switch exhaustive-switch -->
+- Use sequenced collection operations such as `getFirst`, `getLast`, and
+  `reversed` instead of index arithmetic or copied reversals. Remember that
+  reversed views are backed by the original collection.
+  <!-- covers: sequenced-collections reverse-list-iteration -->
+- Use `Math.clamp` for bounded numeric values, preserving its argument-order,
+  NaN, signed-zero, and invalid-range semantics.
+  <!-- covers: math-clamp -->
 - Structured concurrency and scoped values are preview APIs in Java 21; do not
   present them as final for this target.
 
 ## Java 22
 
 - Use unnamed variables and patterns (`_`) when a binding is intentionally
-  unused.
+  unused, not when a meaningful name would document the code.
+  <!-- covers: unnamed-variables -->
 - Use the Foreign Function & Memory API for supported native interop instead of
-  introducing new JNI where its constraints fit. Make arena lifetime and thread
-  confinement explicit.
-- Use the multi-file source launcher for small source-only programs.
-- Use `FileChannel.map` with arenas for explicit mapped-memory lifetime.
-- Do not use stream gatherers or module import declarations as final features.
+  introducing new JNI where it fits. Make arena lifetime, thread confinement,
+  ABI/platform assumptions, restricted methods, and native error handling
+  explicit.
+  <!-- covers: call-c-from-java -->
+- Use `FileChannel.map` with arenas for explicit mapped-memory lifetime. Account
+  for file mutation, address-space pressure, platform unmapping behavior, and
+  access after arena closure.
+  <!-- covers: file-memory-mapping -->
+- Use the multi-file source launcher for small source-only programs whose
+  dependencies fit its source-discovery model; use a normal build for production
+  packaging and complex dependency management.
+  <!-- covers: multi-file-source -->
+- Stream gatherers and module import declarations are not final in Java 22.
 
 ## Java 23
 
-- Use Markdown documentation comments when they improve maintainability of
-  prose-heavy Javadoc.
-- Continue treating module import declarations, compact source files, and
-  primitive patterns as preview features.
+- Use Markdown documentation comments when they improve prose-heavy API docs.
+  Check generated output, links, code fences, and doclint rather than assuming
+  Markdown renders as intended.
+  <!-- covers: markdown-javadoc-comments -->
+- Module import declarations, compact source files, and primitive patterns are
+  preview features on this target.
 
 ## Java 24
 
-- Use stream gatherers for reusable stateful intermediate stream operations
-  when standard operations cannot express the transformation clearly.
-- Consider class-file API and related platform capabilities only when the task
-  actually manipulates bytecode; prefer standard APIs over internal ASM copies.
-- Structured concurrency, scoped values, and compact source files remain
-  preview in Java 24.
+- Use stream gatherers for reusable stateful intermediate operations when
+  standard operations cannot express the transformation clearly. Respect
+  integrator state, short-circuiting, parallel-combiner, and finisher semantics.
+  <!-- covers: stream-gatherers -->
+- Structured concurrency, scoped values, compact source files, stable values,
+  and primitive patterns are not final defaults on this target.
 
 ## Java 25
 
 - Use scoped values for bounded, immutable context propagation, especially with
-  virtual threads; do not use them as mutable globals.
+  virtual threads. Bind values over the smallest dynamic scope and do not use
+  them as mutable globals.
+  <!-- covers: scoped-values -->
 - Use compact source files and instance `main` methods for scripts, teaching,
-  and small programs; retain conventional classes where frameworks or public
-  APIs expect them.
+  and small programs, with `java.lang.IO` for concise console interaction.
+  Retain conventional classes and explicit streams/readers where frameworks,
+  launchers, public APIs, redirection, charset control, or production error
+  handling require them.
+  <!-- covers: compact-source-files io-class-console-io -->
 - Use module import declarations sparingly where broad imports improve small
-  source files without obscuring ownership.
-- Use flexible constructor bodies while preserving the rule that an object
-  cannot be observed before superclass construction.
-- Use the PEM encoding API and key derivation function API instead of hand-made
-  parsing or cryptographic constructions.
-- Evaluate compact object headers and AOT ergonomics with measurements and
-  deployment-specific startup, footprint, and compatibility goals.
-- Structured concurrency and primitive types in patterns are preview in Java
-  25 and require explicit preview configuration. Do not recommend them by
-  default.
+  source files without obscuring symbol ownership or creating ambiguity.
+  <!-- covers: module-import-declarations -->
+- Use flexible constructor bodies for argument validation and preparation before
+  constructor invocation, while preserving the prohibition on observing the
+  under-construction instance.
+  <!-- covers: flexible-constructor-bodies -->
+- Use the final KDF API rather than hand-rolled key derivation. Keep algorithm,
+  salt, work factor, output length, key lifecycle, and protocol interoperability
+  explicit.
+  <!-- covers: key-derivation-functions -->
+- Evaluate compact object headers and AOT cache/training ergonomics with
+  measurements on the deployed workload. Verify GC, serviceability, training
+  representativeness, cache reproducibility, class path, and deployment-image
+  compatibility.
+  <!-- covers: compact-object-headers aot-class-preloading -->
+- **Preview:** Stable Values can replace correct-but-complex lazy initialization
+  when preview is deliberately enabled. Verify initialization, exception,
+  recursion, and contention semantics; do not mechanically replace every holder
+  or memoization pattern.
+  <!-- covers: stable-values lock-free-lazy-init -->
+- **Preview:** Structured concurrency can make related subtasks a single
+  cancellation and failure-propagation unit. Define deadlines, failure policy,
+  result ownership, and interruption behavior.
+  <!-- covers: structured-concurrency -->
+- **Preview:** Primitive types in patterns can combine matching with exact/range
+  checks. Review numeric conversion, overflow, exhaustiveness, and release-specific
+  syntax.
+  <!-- covers: primitive-types-in-patterns -->
+- **Preview:** Use the PEM API only with preview enabled. Validate object type,
+  encryption, algorithm/provider support, malformed input, secret handling, and
+  interoperability; do not conflate it with the final KDF API.
+  <!-- covers: pem-encoding -->
 
 ## Later or unknown targets
 
 Do not assume features beyond Java 25 from this guide. Verify final status
-against the OpenJDK JEP index and the target release documentation. Clearly
-label any preview or incubating API and confirm the exact release syntax.
+against the OpenJDK JEP index and target-release API documentation. Clearly
+label preview or incubating APIs and confirm the exact release syntax.

--- a/agent-plugins/modern-java-development/skills/modern-java/scripts/test_reference_coverage.py
+++ b/agent-plugins/modern-java-development/skills/modern-java/scripts/test_reference_coverage.py
@@ -1,0 +1,28 @@
+import re
+import unittest
+from pathlib import Path
+
+
+class ReferenceCoverageTests(unittest.TestCase):
+    def test_every_catalog_pattern_is_covered_by_reference_guidance(self):
+        repository = Path(__file__).resolve().parents[5]
+        content = repository / "content"
+        if not content.is_dir():
+            self.skipTest("java.evolved catalog is not present in packaged plugin")
+
+        references = Path(__file__).resolve().parents[1] / "references"
+        covered = set()
+        for path in references.glob("*.md"):
+            for marker in re.findall(r"<!--\s*covers:\s*([^>]+)-->", path.read_text()):
+                covered.update(marker.split())
+
+        patterns = {
+            path.stem
+            for path in content.glob("*/*.yaml")
+            if path.name != "template.yaml"
+        }
+        self.assertEqual(set(), patterns - covered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/content/io/io-class-console-io.yaml
+++ b/content/io/io-class-console-io.yaml
@@ -22,12 +22,12 @@ modernCode: |-
   IO.println("Hello, " + name);
 summary: "The new IO class provides simple, concise methods for console input and\
   \ output."
-explanation: "Java 25 introduces the IO class (java.io.IO) as part of the implicitly\
-  \ declared classes feature. It provides static methods like println(), print(),\
+explanation: "Java 25 introduces the IO class (java.lang.IO) alongside the compact\
+  \ source files feature. It provides static methods like println(), print(),\
   \ readln(), and read() that replace the verbose combination of System.out and Scanner.\
   \ IO.readln(prompt) handles both prompting and reading in a single call. The class\
-  \ is automatically available in compact source files and can be used in traditional\
-  \ classes via import."
+  \ is automatically available through java.lang in both compact source files and\
+  \ traditional classes."
 whyModernWins:
 - icon: "✨"
   title: "Dramatically simpler"
@@ -41,8 +41,8 @@ whyModernWins:
   desc: "New developers can do console I/O without learning Scanner, System.out, or\
     \ import statements."
 support:
-  state: "preview"
-  description: "Preview in JDK 25 as part of implicitly declared classes (JEP 495)"
+  state: "available"
+  description: "Finalized in JDK 25 alongside compact source files (JEP 512)"
 prev: "io/http-client"
 next: "io/reading-files"
 related:
@@ -52,7 +52,7 @@ related:
 tags:
 - io
 docs:
-- title: "Simple Source Files (JEP 495)"
-  href: "https://openjdk.org/jeps/495"
+- title: "Compact Source Files and Instance Main Methods (JEP 512)"
+  href: "https://openjdk.org/jeps/512"
 - title: "IO"
   href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/IO.html"


### PR DESCRIPTION
The plugin's reference material covered only a subset of the java.evolved catalog and omitted framework-specific modernization guidance, which could leave agents without the constraints needed for safe recommendations.

This change:
- expands release guidance with behavior and compatibility caveats for every Java SE catalog pattern
- adds dedicated Jakarta EE, MicroProfile, persistence, jOOQ, and Spring guidance
- maps all 113 catalog patterns to reference entries and enforces complete coverage during plugin release validation
- corrects the Java 25 `java.lang.IO` pattern from preview/JEP 495 to final/JEP 512

The plugin detector and reference coverage tests pass, and the corrected IO proof compiles on Java 25.