### PR TITLE
Fix Browse patterns hash filtering

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -302,7 +302,9 @@
         if (target) {
           selectItem(target);
           toggleBtn.classList.toggle('has-filter', value !== 'all');
+          return true;
         }
+        return false;
       }};
     };
 
@@ -331,8 +333,7 @@
 
     // Apply filter from a given category string (or "all" / empty for no filter)
     const applyHashFilter = (category) => {
-      if (category && catDropdownCtrl) {
-        catDropdownCtrl.setActive(category);
+      if (category && catDropdownCtrl && catDropdownCtrl.setActive(category)) {
         activeCategory = category;
         applyFilters();
         const section = document.getElementById('all-comparisons');


### PR DESCRIPTION
Clicking Browse patterns updates the URL to `#all-comparisons`, which was incorrectly treated as a category and hid every card.

Only apply hash-based filtering when the hash matches an available category option. Section anchors now retain the default all-patterns view.