### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,9 +11,9 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -21,7 +21,7 @@ jobs:
       - uses: jbangdev/setup-jbang@main
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
@@ -160,9 +160,9 @@ jobs:
   build-jar:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -177,7 +177,7 @@ jobs:
           java -XX:AOTCacheOutput=html-generators/generateog.aot -jar html-generators/generateog.jar
 
       - name: Upload JAR and AOT
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: generator
           path: |
@@ -190,15 +190,15 @@ jobs:
     needs: build-jar
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '25'
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.13'
 
@@ -209,7 +209,7 @@ jobs:
         run: pip install pyyaml cairosvg
 
       - name: Download JAR and AOT
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: generator
           path: html-generators

--- a/.github/workflows/build-generator.yml
+++ b/.github/workflows/build-generator.yml
@@ -19,9 +19,9 @@ jobs:
   build-generate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -35,7 +35,7 @@ jobs:
         run: java -XX:AOTCacheOutput=html-generators/generate.aot -jar html-generators/generate.jar
 
       - name: Save to cache
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           path: |
             html-generators/generate.jar
@@ -45,9 +45,9 @@ jobs:
   build-generateog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -61,7 +61,7 @@ jobs:
         run: java -XX:AOTCacheOutput=html-generators/generateog.aot -jar html-generators/generateog.jar
 
       - name: Save to cache
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           path: |
             html-generators/generateog.jar

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -11,8 +11,8 @@ jobs:
       contents: read
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Install gh-aw extension
-      uses: github/gh-aw/actions/setup-cli@v0.50.4
+      uses: github/gh-aw/actions/setup-cli@v0.86.2
       with:
-        version: v0.50.4
+        version: v0.86.2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 2
 
@@ -63,7 +63,7 @@ jobs:
           fi
           echo "Summary: generate=${{ steps.changes.outputs.generate || 'pending' }}, og=${{ steps.changes.outputs.og || 'pending' }}"
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         if: steps.changes.outputs.generate == 'true' || steps.changes.outputs.og == 'true'
         with:
           distribution: 'temurin'
@@ -73,7 +73,7 @@ jobs:
       - name: Restore cached generate JAR and AOT
         id: cache-restore
         if: steps.changes.outputs.generate == 'true'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: |
             html-generators/generate.jar
@@ -96,7 +96,7 @@ jobs:
       - name: Restore cached generateog JAR and AOT
         id: cache-restore-og
         if: steps.changes.outputs.og == 'true'
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: |
             html-generators/generateog.jar
@@ -118,10 +118,10 @@ jobs:
           jbang html-generators/generateog.java
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -134,4 +134,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -17,9 +17,9 @@ jobs:
   proof:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '25'

--- a/.github/workflows/release-agent-plugin.yml
+++ b/.github/workflows/release-agent-plugin.yml
@@ -31,7 +31,7 @@ jobs:
           echo "::error::Agent plugin releases must be run from the main branch."
           exit 1
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/social-post.yml
+++ b/.github/workflows/social-post.yml
@@ -16,9 +16,9 @@ jobs:
   post:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '25'


### PR DESCRIPTION
Keep CI workflows on supported action runtimes and current upstream releases.

Updates the maintained GitHub Actions used across build, deployment, benchmark, proof, release, social posting, and Copilot setup workflows. This includes the latest major versions of the official actions and upgrades `github/gh-aw` from `v0.50.4` to `v0.86.2`. `jbangdev/setup-jbang@main` remains unchanged because its latest tagged release is older than the current main branch.