### PR TITLE
Require tags for new code patterns

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,6 +48,7 @@ Content files are YAML (preferred) or JSON under `content/{category}/{slug}.yaml
 | `category` | Must match parent folder name |
 | `whyModernWins` | Exactly **3** entries, each with `icon`, `title`, `desc` |
 | `related` | Exactly **3** entries as `category/slug` paths (cross-category OK) |
+| `tags` | Non-empty list of slugs registered in `html-generators/tags.properties` |
 | `docs` | At least **1** entry with `title` and `href` |
 | `prev` / `next` | `category/slug` path or `null` for first/last in the global chain |
 | `jdkVersion` | The JDK version where the feature became **final** (not preview) |
@@ -57,10 +58,11 @@ Content files are YAML (preferred) or JSON under `content/{category}/{slug}.yaml
 ### Adding a new pattern
 
 1. Create `content/{category}/new-slug.yaml` with all required fields (use `content/template.json` as reference).
-2. Update `prev`/`next` in the adjacent patterns to maintain the navigation chain.
-3. Create `proof/{category}/{PascalCaseSlug}.java` — JBang script wrapping the modern code.
-4. Run `jbang html-generators/generate.java` and verify it completes.
-5. Translations are optional — the AI translation workflow handles them, or create partial files under `translations/content/{locale}/`.
+2. Add a non-empty `tags` list. Every tag slug must already exist in `html-generators/tags.properties`; add new `slug=Display Name` entries there in the same change.
+3. Update `prev`/`next` in the adjacent patterns to maintain the navigation chain.
+4. Create `proof/{category}/{PascalCaseSlug}.java` — JBang script wrapping the modern code.
+5. Run `jbang html-generators/generate.java` and verify it completes. The generator rejects missing, empty, malformed, and unregistered tags.
+6. Translations are optional — the AI translation workflow handles them, or create partial files under `translations/content/{locale}/`.
 
 ### Removing or reordering a pattern
 

--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -1,0 +1,33 @@
+name: Content Validation
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/content-validation.yml'
+      - 'content/**'
+      - 'translations/**'
+      - 'templates/**'
+      - 'html-generators/generate.java'
+      - 'html-generators/tags.properties'
+      - 'html-generators/categories.properties'
+      - 'html-generators/locales.properties'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v6
+        with:
+          distribution: 'temurin'
+          java-version: '25'
+
+      - uses: jbangdev/setup-jbang@main
+
+      - name: Validate content and generate site
+        run: jbang html-generators/generate.java

--- a/.github/workflows/proof.yml
+++ b/.github/workflows/proof.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-java@v6
         with:
@@ -26,14 +28,27 @@ jobs:
 
       - uses: jbangdev/setup-jbang@main
 
-      - name: Run all proof scripts
+      - name: Run proof scripts
         shell: bash
         run: |
           passed=0
           failed=0
           failures=()
+          scripts=()
 
-          while IFS= read -r -d '' script; do
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            while IFS= read -r -d '' script; do
+              [[ "$script" == *.java ]] && scripts+=("$script")
+            done < <(git diff --name-only --diff-filter=ACMR -z \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}" -- proof/)
+          else
+            while IFS= read -r -d '' script; do
+              scripts+=("$script")
+            done < <(find proof -name '*.java' -print0 | sort -z)
+          fi
+
+          for script in "${scripts[@]}"; do
             name="${script#proof/}"
             if jbang "$script" > /dev/null 2>&1; then
               echo "✅ $name"
@@ -43,7 +58,7 @@ jobs:
               failures+=("$name")
               failed=$((failed + 1))
             fi
-          done < <(find proof -name '*.java' -print0 | sort -z)
+          done
 
           echo ""
           echo "Results: $passed passed, $failed failed out of $((passed + failed)) scripts"

--- a/html-generators/generate.java
+++ b/html-generators/generate.java
@@ -179,7 +179,9 @@ record Snippet(JsonNode node) {
 
     List<String> tags() {
         var t = node.get("tags");
-        if (t == null || !t.isArray()) return List.of();
+        if (t == null || !t.isArray() || t.isEmpty()) {
+            throw new IllegalArgumentException("Missing or empty tags array in " + key());
+        }
         var tagList = new ArrayList<String>();
         t.forEach(n -> {
             var tag = n.asText().strip();


### PR DESCRIPTION
New code patterns can currently merge with missing or unregistered tags because content generation only runs after changes reach `main`. This adds pre-merge validation so tag mistakes are caught in the originating PR.

- Run the site generator on pull requests that modify content or generator inputs.
- Reject patterns whose `tags` field is missing, empty, malformed, or references an unregistered slug.
- Document the tag and registry requirements for Copilot and other coding agents.
- Run only added or modified proof scenarios in pull requests, while retaining the full proof suite for `main` and manual runs.