### PR TITLE
Add Stack to Deque and ArrayDeque pattern

### DIFF
--- a/content/collections/stack-to-deque.yaml
+++ b/content/collections/stack-to-deque.yaml
@@ -1,5 +1,5 @@
 ---
-id: 115
+id: 5ec6dc04-e96e-4d30-a11c-ea48c9d28fbf
 slug: "stack-to-deque"
 title: "Stack to Deque and ArrayDeque"
 category: "collections"

--- a/content/collections/stack-to-deque.yaml
+++ b/content/collections/stack-to-deque.yaml
@@ -1,0 +1,49 @@
+---
+id: 115
+slug: "stack-to-deque"
+title: "Stack to Deque and ArrayDeque"
+category: "collections"
+difficulty: "beginner"
+jdkVersion: "6"
+oldLabel: "Legacy Stack"
+modernLabel: "Deque API"
+oldApproach: "Stack"
+modernApproach: "Deque with ArrayDeque"
+oldCode: |-
+  Stack<String> stack = new Stack<>();
+  stack.push("task");
+  String next = stack.pop();
+modernCode: |-
+  Deque<String> stack = new ArrayDeque<>();
+  stack.push("task");
+  String next = stack.pop();
+summary: "Use the Deque interface with ArrayDeque instead of the legacy Stack class."
+explanation: "Stack extends the legacy synchronized Vector class. Deque models stack operations directly, and ArrayDeque is the preferred general-purpose implementation for in-memory LIFO work."
+whyModernWins:
+- icon: "🎯"
+  title: "Better abstraction"
+  desc: "Deque explicitly models both stack and queue operations."
+- icon: "⚡"
+  title: "Lower overhead"
+  desc: "ArrayDeque avoids Vector's legacy synchronization."
+- icon: "🧩"
+  title: "More flexible"
+  desc: "The same interface supports LIFO and FIFO algorithms."
+support:
+  state: "available"
+  description: "Available since JDK 6 (December 2006)"
+prev: "enterprise/spring-boot-mvc-config"
+next: null
+related:
+- "collections/sequenced-collections"
+- "collections/reverse-list-iteration"
+- "collections/immutable-list-creation"
+tags:
+- collections
+docs:
+- title: "Deque (Java 25)"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Deque.html"
+- title: "ArrayDeque (Java 25)"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/ArrayDeque.html"
+- title: "Stack (Java 25)"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Stack.html"

--- a/content/enterprise/spring-boot-mvc-config.yaml
+++ b/content/enterprise/spring-boot-mvc-config.yaml
@@ -44,7 +44,7 @@ support:
   state: "available"
   description: "Available in Spring Boot 4.0 with Spring Framework 7.0 (requires Java 17+)"
 prev: "enterprise/spring-null-safety-jspecify"
-next: null
+next: "collections/stack-to-deque"
 related:
 - "enterprise/spring-api-versioning"
 - "enterprise/spring-xml-config-vs-annotations"

--- a/proof/collections/StackToDeque.java
+++ b/proof/collections/StackToDeque.java
@@ -1,0 +1,12 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 25+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/// Proof: stack-to-deque
+/// Source: content/collections/stack-to-deque.yaml
+void main() {
+    Deque<String> stack = new ArrayDeque<>();
+    stack.push("task");
+    String next = stack.pop();
+}


### PR DESCRIPTION
`Stack` remains common in older Java code despite extending the legacy synchronized `Vector` class. This adds a beginner-focused modernization pattern that recommends the `Deque` abstraction with `ArrayDeque` for general-purpose LIFO work.

The pattern includes the side-by-side API comparison, JDK 6 support metadata, official Java API references, related collection patterns, and a compilable JBang proof. It is appended to the global pattern navigation chain after the current final entry.

Fixes: #179