### PR TITLE
Use UUIDs for pattern IDs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,6 +44,7 @@ Content files are YAML (preferred) or JSON under `content/{category}/{slug}.yaml
 
 | Field | Constraint |
 |-------|-----------|
+| `id` | Unique UUID string (generate independently with `uuidgen`) |
 | `slug` | Must match filename (without extension) |
 | `category` | Must match parent folder name |
 | `whyModernWins` | Exactly **3** entries, each with `icon`, `title`, `desc` |
@@ -57,11 +58,11 @@ Content files are YAML (preferred) or JSON under `content/{category}/{slug}.yaml
 
 ### Adding a new pattern
 
-1. Create `content/{category}/new-slug.yaml` with all required fields (use `content/template.json` as reference).
+1. Create `content/{category}/new-slug.yaml` with all required fields (use `content/template.json` as reference) and generate its `id` with `uuidgen`.
 2. Add a non-empty `tags` list. Every tag slug must already exist in `html-generators/tags.properties`; add new `slug=Display Name` entries there in the same change.
 3. Update `prev`/`next` in the adjacent patterns to maintain the navigation chain.
 4. Create `proof/{category}/{PascalCaseSlug}.java` — JBang script wrapping the modern code.
-5. Run `jbang html-generators/generate.java` and verify it completes. The generator rejects missing, empty, malformed, and unregistered tags.
+5. Run `jbang html-generators/generate.java` and verify it completes. The generator rejects missing, malformed, or duplicate UUIDs as well as missing, empty, malformed, and unregistered tags.
 6. Translations are optional — the AI translation workflow handles them, or create partial files under `translations/content/{locale}/`.
 
 ### Removing or reordering a pattern

--- a/content/collections/collectors-teeing.yaml
+++ b/content/collections/collectors-teeing.yaml
@@ -1,5 +1,5 @@
 ---
-id: 26
+id: a04b95a4-d198-4e96-ac9b-870ec57fdeb9
 slug: "collectors-teeing"
 title: "Collectors.teeing()"
 category: "collections"

--- a/content/collections/copying-collections-immutably.yaml
+++ b/content/collections/copying-collections-immutably.yaml
@@ -1,5 +1,5 @@
 ---
-id: 22
+id: 34332f56-c837-4ddb-b00f-aca32bb68bef
 slug: "copying-collections-immutably"
 title: "Copying collections immutably"
 category: "collections"

--- a/content/collections/immutable-list-creation.yaml
+++ b/content/collections/immutable-list-creation.yaml
@@ -1,5 +1,5 @@
 ---
-id: 19
+id: 1fa578db-e750-4adb-a88e-bdd2bbda14c4
 slug: "immutable-list-creation"
 title: "Immutable list creation"
 category: "collections"

--- a/content/collections/immutable-map-creation.yaml
+++ b/content/collections/immutable-map-creation.yaml
@@ -1,5 +1,5 @@
 ---
-id: 20
+id: d118236d-2cfb-4c8a-81b6-f870fc10c25d
 slug: "immutable-map-creation"
 title: "Immutable map creation"
 category: "collections"

--- a/content/collections/immutable-set-creation.yaml
+++ b/content/collections/immutable-set-creation.yaml
@@ -1,5 +1,5 @@
 ---
-id: 21
+id: 26dee8f0-333e-44ae-9467-4c99bae5516a
 slug: "immutable-set-creation"
 title: "Immutable set creation"
 category: "collections"

--- a/content/collections/map-entry-factory.yaml
+++ b/content/collections/map-entry-factory.yaml
@@ -1,5 +1,5 @@
 ---
-id: 23
+id: 672534a8-9e26-4d9d-b448-a48ca562519f
 slug: "map-entry-factory"
 title: "Map.entry() factory"
 category: "collections"

--- a/content/collections/reverse-list-iteration.yaml
+++ b/content/collections/reverse-list-iteration.yaml
@@ -1,5 +1,5 @@
 ---
-id: 96
+id: ed019aff-c1e9-462a-9750-79d27891cee4
 slug: "reverse-list-iteration"
 title: "Reverse list iteration"
 category: "collections"

--- a/content/collections/sequenced-collections.yaml
+++ b/content/collections/sequenced-collections.yaml
@@ -1,5 +1,5 @@
 ---
-id: 24
+id: 8d95ed1f-c10f-49c9-8427-916904b5ce92
 slug: "sequenced-collections"
 title: "Sequenced collections"
 category: "collections"

--- a/content/collections/stream-toarray-typed.yaml
+++ b/content/collections/stream-toarray-typed.yaml
@@ -1,5 +1,5 @@
 ---
-id: 27
+id: 5af66a72-0bcb-4c3a-9237-678c149ccef3
 slug: "stream-toarray-typed"
 title: "Typed stream toArray"
 category: "collections"

--- a/content/collections/unmodifiable-collectors.yaml
+++ b/content/collections/unmodifiable-collectors.yaml
@@ -1,5 +1,5 @@
 ---
-id: 28
+id: 4ed99b6a-ef57-4769-a640-46521d03b190
 slug: "unmodifiable-collectors"
 title: "Unmodifiable collectors"
 category: "collections"

--- a/content/concurrency/completablefuture-chaining.yaml
+++ b/content/concurrency/completablefuture-chaining.yaml
@@ -1,5 +1,5 @@
 ---
-id: 50
+id: 1abbda8c-c7e3-42d1-874e-978403c51325
 slug: "completablefuture-chaining"
 title: "CompletableFuture chaining"
 category: "concurrency"

--- a/content/concurrency/concurrent-http-virtual.yaml
+++ b/content/concurrency/concurrent-http-virtual.yaml
@@ -1,5 +1,5 @@
 ---
-id: 54
+id: 70ce47ef-a05c-4e30-8801-376665667e93
 slug: "concurrent-http-virtual"
 title: "Concurrent HTTP with virtual threads"
 category: "concurrency"

--- a/content/concurrency/executor-try-with-resources.yaml
+++ b/content/concurrency/executor-try-with-resources.yaml
@@ -1,5 +1,5 @@
 ---
-id: 51
+id: 504dc724-f73d-4b16-8be0-41098927b23a
 slug: "executor-try-with-resources"
 title: "ExecutorService auto-close"
 category: "concurrency"

--- a/content/concurrency/lock-free-lazy-init.yaml
+++ b/content/concurrency/lock-free-lazy-init.yaml
@@ -1,5 +1,5 @@
 ---
-id: 55
+id: d8c32443-3da4-462b-9a37-ffaff0dbf3ec
 slug: "lock-free-lazy-init"
 title: "Lock-free lazy initialization"
 category: "concurrency"

--- a/content/concurrency/process-api.yaml
+++ b/content/concurrency/process-api.yaml
@@ -1,5 +1,5 @@
 ---
-id: 53
+id: a906e3e4-2027-44b6-a030-adb804e5d9df
 slug: "process-api"
 title: "Modern Process API"
 category: "concurrency"

--- a/content/concurrency/scoped-values.yaml
+++ b/content/concurrency/scoped-values.yaml
@@ -1,5 +1,5 @@
 ---
-id: 48
+id: 96fc59e8-7ac1-429b-8195-2aa6003e757b
 slug: "scoped-values"
 title: "Scoped values"
 category: "concurrency"

--- a/content/concurrency/stable-values.yaml
+++ b/content/concurrency/stable-values.yaml
@@ -1,5 +1,5 @@
 ---
-id: 49
+id: f26967f9-4e25-452a-b727-17e98f62f9cc
 slug: "stable-values"
 title: "Stable values"
 category: "concurrency"

--- a/content/concurrency/structured-concurrency.yaml
+++ b/content/concurrency/structured-concurrency.yaml
@@ -1,5 +1,5 @@
 ---
-id: 47
+id: fd8d3592-2eb6-439c-bca7-15fc9953a275
 slug: "structured-concurrency"
 title: "Structured concurrency"
 category: "concurrency"

--- a/content/concurrency/thread-sleep-duration.yaml
+++ b/content/concurrency/thread-sleep-duration.yaml
@@ -1,5 +1,5 @@
 ---
-id: 52
+id: d19e2c63-defa-4792-be7e-56ec4ced993c
 slug: "thread-sleep-duration"
 title: "Thread.sleep with Duration"
 category: "concurrency"

--- a/content/concurrency/virtual-threads.yaml
+++ b/content/concurrency/virtual-threads.yaml
@@ -1,5 +1,5 @@
 ---
-id: 46
+id: 9f4e06bf-c694-49b3-a40b-7a0aef7a5df8
 slug: "virtual-threads"
 title: "Virtual threads"
 category: "concurrency"

--- a/content/datetime/date-formatting.yaml
+++ b/content/datetime/date-formatting.yaml
@@ -1,5 +1,5 @@
 ---
-id: 72
+id: 1d3de988-2e5c-44a7-8fd4-f8d589406f1b
 slug: "date-formatting"
 title: "Date formatting"
 category: "datetime"

--- a/content/datetime/duration-and-period.yaml
+++ b/content/datetime/duration-and-period.yaml
@@ -1,5 +1,5 @@
 ---
-id: 71
+id: eaf765f9-0a5b-4644-9447-72211a1c96e5
 slug: "duration-and-period"
 title: "Duration and Period"
 category: "datetime"

--- a/content/datetime/hex-format.yaml
+++ b/content/datetime/hex-format.yaml
@@ -1,5 +1,5 @@
 ---
-id: 75
+id: c6cb183e-8a07-46e1-a962-62b47c08ce48
 slug: "hex-format"
 title: "HexFormat"
 category: "datetime"

--- a/content/datetime/instant-precision.yaml
+++ b/content/datetime/instant-precision.yaml
@@ -1,5 +1,5 @@
 ---
-id: 73
+id: ab1ba9f1-fe99-471f-8625-cdd0eb95073e
 slug: "instant-precision"
 title: "Instant with nanosecond precision"
 category: "datetime"

--- a/content/datetime/java-time-basics.yaml
+++ b/content/datetime/java-time-basics.yaml
@@ -1,5 +1,5 @@
 ---
-id: 70
+id: af22c838-38b0-430a-bcdf-a66924d38e46
 slug: "java-time-basics"
 title: "java.time API basics"
 category: "datetime"

--- a/content/datetime/math-clamp.yaml
+++ b/content/datetime/math-clamp.yaml
@@ -1,5 +1,5 @@
 ---
-id: 74
+id: 0c439d08-8fc7-4f63-947f-001a8a56c837
 slug: "math-clamp"
 title: "Math.clamp()"
 category: "datetime"

--- a/content/enterprise/ejb-timer-vs-jakarta-scheduler.yaml
+++ b/content/enterprise/ejb-timer-vs-jakarta-scheduler.yaml
@@ -1,5 +1,5 @@
 ---
-id: 102
+id: 0d972e66-0b9b-4351-ba43-3b176673033e
 slug: "ejb-timer-vs-jakarta-scheduler"
 title: "EJB Timer vs Jakarta Scheduler"
 category: "enterprise"

--- a/content/enterprise/ejb-vs-cdi.yaml
+++ b/content/enterprise/ejb-vs-cdi.yaml
@@ -1,5 +1,5 @@
 ---
-id: 99
+id: 7eafcb07-f9ed-49cb-bc68-0bf24eb9b675
 slug: "ejb-vs-cdi"
 title: "EJB versus CDI"
 category: "enterprise"

--- a/content/enterprise/jdbc-resultset-vs-jpa-criteria.yaml
+++ b/content/enterprise/jdbc-resultset-vs-jpa-criteria.yaml
@@ -1,5 +1,5 @@
 ---
-id: 109
+id: 70e5cbb0-d5f9-474f-b302-0e6494433bab
 slug: "jdbc-resultset-vs-jpa-criteria"
 title: "JDBC ResultSet Mapping vs JPA Criteria API"
 category: "enterprise"

--- a/content/enterprise/jdbc-vs-jooq.yaml
+++ b/content/enterprise/jdbc-vs-jooq.yaml
@@ -1,5 +1,5 @@
 ---
-id: 112
+id: 103bdb91-97aa-46bd-a7a6-d372c26a40a2
 slug: "jdbc-vs-jooq"
 title: "JDBC versus jOOQ"
 category: "enterprise"

--- a/content/enterprise/jdbc-vs-jpa.yaml
+++ b/content/enterprise/jdbc-vs-jpa.yaml
@@ -1,5 +1,5 @@
 ---
-id: 100
+id: 9a27cf95-647d-49fd-a523-80ef7fdc4215
 slug: "jdbc-vs-jpa"
 title: "JDBC versus JPA"
 category: "enterprise"

--- a/content/enterprise/jndi-lookup-vs-cdi-injection.yaml
+++ b/content/enterprise/jndi-lookup-vs-cdi-injection.yaml
@@ -1,5 +1,5 @@
 ---
-id: 103
+id: 54b095f1-9ca0-4d08-b151-dcecfac87c31
 slug: "jndi-lookup-vs-cdi-injection"
 title: "JNDI Lookup vs CDI Injection"
 category: "enterprise"

--- a/content/enterprise/jpa-vs-jakarta-data.yaml
+++ b/content/enterprise/jpa-vs-jakarta-data.yaml
@@ -1,5 +1,5 @@
 ---
-id: 101
+id: a278dac4-599c-4148-96bb-4e9b9ec23b3f
 slug: "jpa-vs-jakarta-data"
 title: "JPA versus Jakarta Data"
 category: "enterprise"

--- a/content/enterprise/jsf-managed-bean-vs-cdi-named.yaml
+++ b/content/enterprise/jsf-managed-bean-vs-cdi-named.yaml
@@ -1,5 +1,5 @@
 ---
-id: 107
+id: f52bebd0-05a6-43ff-b67a-463103bb475d
 slug: "jsf-managed-bean-vs-cdi-named"
 title: "JSF Managed Bean vs CDI Named Bean"
 category: "enterprise"

--- a/content/enterprise/manual-transaction-vs-declarative.yaml
+++ b/content/enterprise/manual-transaction-vs-declarative.yaml
@@ -1,5 +1,5 @@
 ---
-id: 104
+id: f547e15a-f151-45e2-9000-a9b20498b4e9
 slug: "manual-transaction-vs-declarative"
 title: "Manual JPA Transaction vs Declarative @Transactional"
 category: "enterprise"

--- a/content/enterprise/mdb-vs-reactive-messaging.yaml
+++ b/content/enterprise/mdb-vs-reactive-messaging.yaml
@@ -1,5 +1,5 @@
 ---
-id: 106
+id: cccaa39a-3698-4fd3-b11c-2a712d57d307
 slug: "mdb-vs-reactive-messaging"
 title: "Message-Driven Bean vs Reactive Messaging"
 category: "enterprise"

--- a/content/enterprise/servlet-vs-jaxrs.yaml
+++ b/content/enterprise/servlet-vs-jaxrs.yaml
@@ -1,5 +1,5 @@
 ---
-id: 98
+id: a7ba2242-b9f0-4b1a-80b7-4a5dfee925cf
 slug: "servlet-vs-jaxrs"
 title: "Servlet versus JAX-RS"
 category: "enterprise"

--- a/content/enterprise/singleton-ejb-vs-cdi-application-scoped.yaml
+++ b/content/enterprise/singleton-ejb-vs-cdi-application-scoped.yaml
@@ -1,5 +1,5 @@
 ---
-id: 108
+id: 942229f5-9ef4-4f75-97b9-1bcf19db757b
 slug: "singleton-ejb-vs-cdi-application-scoped"
 title: "Singleton EJB vs CDI @ApplicationScoped"
 category: "enterprise"

--- a/content/enterprise/soap-vs-jakarta-rest.yaml
+++ b/content/enterprise/soap-vs-jakarta-rest.yaml
@@ -1,5 +1,5 @@
 ---
-id: 105
+id: 13f68067-6369-4aa0-9241-2d7d18538500
 slug: "soap-vs-jakarta-rest"
 title: "SOAP Web Services vs Jakarta REST"
 category: "enterprise"

--- a/content/enterprise/spring-api-versioning.yaml
+++ b/content/enterprise/spring-api-versioning.yaml
@@ -1,5 +1,5 @@
 ---
-id: 110
+id: 5c5fa7f9-24a8-43e0-b227-142f3972d4e4
 slug: "spring-api-versioning"
 title: "Spring Framework 7 API Versioning"
 category: "enterprise"

--- a/content/enterprise/spring-boot-mvc-config.yaml
+++ b/content/enterprise/spring-boot-mvc-config.yaml
@@ -1,5 +1,5 @@
 ---
-id: 114
+id: 51007825-4ecf-4f6e-9213-402e09116aca
 slug: "spring-boot-mvc-config"
 title: "Spring Boot MVC Configuration"
 category: "enterprise"

--- a/content/enterprise/spring-null-safety-jspecify.yaml
+++ b/content/enterprise/spring-null-safety-jspecify.yaml
@@ -1,5 +1,5 @@
 ---
-id: 110
+id: 9d441016-467a-4c05-948d-aab86f1981f7
 slug: "spring-null-safety-jspecify"
 title: "Spring Null Safety with JSpecify"
 category: "enterprise"

--- a/content/enterprise/spring-xml-config-vs-annotations.yaml
+++ b/content/enterprise/spring-xml-config-vs-annotations.yaml
@@ -1,5 +1,5 @@
 ---
-id: 110
+id: ba351e98-dd21-4c47-a6a0-547233992ac1
 slug: "spring-xml-config-vs-annotations"
 title: "Spring XML Bean Config vs Annotation-Driven"
 category: "enterprise"

--- a/content/errors/helpful-npe.yaml
+++ b/content/errors/helpful-npe.yaml
@@ -1,5 +1,5 @@
 ---
-id: 64
+id: 453cca55-87e3-4b5e-a1e0-32f76f6339c0
 slug: "helpful-npe"
 title: "Helpful NullPointerExceptions"
 category: "errors"

--- a/content/errors/multi-catch.yaml
+++ b/content/errors/multi-catch.yaml
@@ -1,5 +1,5 @@
 ---
-id: 67
+id: a1e10d18-a8b7-439b-9cc9-e3ce363c6588
 slug: "multi-catch"
 title: "Multi-catch exception handling"
 category: "errors"

--- a/content/errors/null-in-switch.yaml
+++ b/content/errors/null-in-switch.yaml
@@ -1,5 +1,5 @@
 ---
-id: 68
+id: 6e23cb16-86d8-4926-abdd-2cff4b3c4261
 slug: "null-in-switch"
 title: "Null case in switch"
 category: "errors"

--- a/content/errors/optional-chaining.yaml
+++ b/content/errors/optional-chaining.yaml
@@ -1,5 +1,5 @@
 ---
-id: 65
+id: 1daf2b09-44c9-4f4d-aa61-de99c038d9e8
 slug: "optional-chaining"
 title: "Optional chaining"
 category: "errors"

--- a/content/errors/optional-orelsethrow.yaml
+++ b/content/errors/optional-orelsethrow.yaml
@@ -1,5 +1,5 @@
 ---
-id: 88
+id: a8a1d88a-770e-4a7d-8d3f-553ca22897fd
 slug: "optional-orelsethrow"
 title: "Optional.orElseThrow() without supplier"
 category: "errors"

--- a/content/errors/record-based-errors.yaml
+++ b/content/errors/record-based-errors.yaml
@@ -1,5 +1,5 @@
 ---
-id: 69
+id: 01ba1bd0-2797-410d-bc59-cc1fe01e30e8
 slug: "record-based-errors"
 title: "Record-based error responses"
 category: "errors"

--- a/content/errors/require-nonnull-else.yaml
+++ b/content/errors/require-nonnull-else.yaml
@@ -1,5 +1,5 @@
 ---
-id: 66
+id: 1cda30b5-de48-4167-bfb0-8021e259b181
 slug: "require-nonnull-else"
 title: "Objects.requireNonNullElse()"
 category: "errors"

--- a/content/io/deserialization-filters.yaml
+++ b/content/io/deserialization-filters.yaml
@@ -1,5 +1,5 @@
 ---
-id: 63
+id: bc2d6fd6-e255-45ed-b4ad-2ec5035929cd
 slug: "deserialization-filters"
 title: "Deserialization filters"
 category: "io"

--- a/content/io/file-memory-mapping.yaml
+++ b/content/io/file-memory-mapping.yaml
@@ -1,5 +1,5 @@
 ---
-id: 97
+id: 39bb4e57-3ece-4d13-8e54-c6c82cc6e5ca
 slug: "file-memory-mapping"
 title: "File memory mapping"
 category: "io"

--- a/content/io/files-mismatch.yaml
+++ b/content/io/files-mismatch.yaml
@@ -1,5 +1,5 @@
 ---
-id: 62
+id: d3a8a303-63dc-4880-9124-558cf0f6f598
 slug: "files-mismatch"
 title: "Files.mismatch()"
 category: "io"

--- a/content/io/http-client.yaml
+++ b/content/io/http-client.yaml
@@ -1,5 +1,5 @@
 ---
-id: 56
+id: 785a633d-2dd2-4e09-a3a1-be7b38fa5700
 slug: "http-client"
 title: "Modern HTTP client"
 category: "io"

--- a/content/io/inputstream-transferto.yaml
+++ b/content/io/inputstream-transferto.yaml
@@ -1,5 +1,5 @@
 ---
-id: 59
+id: be0111a0-1b64-4d6e-bca9-a004bde4dd18
 slug: "inputstream-transferto"
 title: "InputStream.transferTo()"
 category: "io"

--- a/content/io/io-class-console-io.yaml
+++ b/content/io/io-class-console-io.yaml
@@ -1,5 +1,5 @@
 ---
-id: 90
+id: 137e082b-bbac-4a62-a5c3-741e343862e6
 slug: "io-class-console-io"
 title: "IO class for console I/O"
 category: "io"

--- a/content/io/path-of.yaml
+++ b/content/io/path-of.yaml
@@ -1,5 +1,5 @@
 ---
-id: 60
+id: b1daeb4c-3014-4552-919b-f2bf7ffacda6
 slug: "path-of"
 title: "Path.of() factory"
 category: "io"

--- a/content/io/reading-files.yaml
+++ b/content/io/reading-files.yaml
@@ -1,5 +1,5 @@
 ---
-id: 57
+id: 4b4ea893-b7b3-486f-a989-fb3f615fbeae
 slug: "reading-files"
 title: "Reading files"
 category: "io"

--- a/content/io/try-with-resources-effectively-final.yaml
+++ b/content/io/try-with-resources-effectively-final.yaml
@@ -1,5 +1,5 @@
 ---
-id: 61
+id: 8a24c403-b30c-4506-b6d7-9de7aecbd949
 slug: "try-with-resources-effectively-final"
 title: "Try-with-resources improvement"
 category: "io"

--- a/content/io/writing-files.yaml
+++ b/content/io/writing-files.yaml
@@ -1,5 +1,5 @@
 ---
-id: 58
+id: 5c8f3738-5720-4977-83ee-3ea49ed5b44a
 slug: "writing-files"
 title: "Writing files"
 category: "io"

--- a/content/language/call-c-from-java.yaml
+++ b/content/language/call-c-from-java.yaml
@@ -1,5 +1,5 @@
 ---
-id: 113
+id: 48ac8b15-9ed0-46b4-98b0-064c32b68aad
 slug: "call-c-from-java"
 title: "Calling out to C code from Java"
 category: "language"

--- a/content/language/compact-canonical-constructor.yaml
+++ b/content/language/compact-canonical-constructor.yaml
@@ -1,5 +1,5 @@
 ---
-id: 95
+id: 1e1f7ac8-24b5-4771-b26e-5ef026ca3edf
 slug: "compact-canonical-constructor"
 title: "Compact canonical constructor"
 category: "language"

--- a/content/language/compact-source-files.yaml
+++ b/content/language/compact-source-files.yaml
@@ -1,5 +1,5 @@
 ---
-id: 9
+id: e787e48c-00e6-489b-9537-d3139f7b3735
 slug: "compact-source-files"
 title: "Compact source files"
 category: "language"

--- a/content/language/default-interface-methods.yaml
+++ b/content/language/default-interface-methods.yaml
@@ -1,5 +1,5 @@
 ---
-id: 86
+id: 3e06bdce-3f1a-4a62-887d-00189dd2d858
 slug: "default-interface-methods"
 title: "Default interface methods"
 category: "language"

--- a/content/language/diamond-operator.yaml
+++ b/content/language/diamond-operator.yaml
@@ -1,5 +1,5 @@
 ---
-id: 12
+id: 73d4af75-dfcb-4e0b-8aa1-10c6df90b653
 slug: "diamond-operator"
 title: "Diamond with anonymous classes"
 category: "language"

--- a/content/language/exhaustive-switch.yaml
+++ b/content/language/exhaustive-switch.yaml
@@ -1,5 +1,5 @@
 ---
-id: 18
+id: ffc40f37-bcf4-4297-9e1d-8b2cecc4c148
 slug: "exhaustive-switch"
 title: "Exhaustive switch without default"
 category: "language"

--- a/content/language/flexible-constructor-bodies.yaml
+++ b/content/language/flexible-constructor-bodies.yaml
@@ -1,5 +1,5 @@
 ---
-id: 10
+id: 8d9fcbac-2d1f-4ee6-9421-2f4538fe9c3d
 slug: "flexible-constructor-bodies"
 title: "Flexible constructor bodies"
 category: "language"

--- a/content/language/guarded-patterns.yaml
+++ b/content/language/guarded-patterns.yaml
@@ -1,5 +1,5 @@
 ---
-id: 15
+id: a0a359b3-2d7e-4bc9-9e98-72fdb1287c89
 slug: "guarded-patterns"
 title: "Guarded patterns with when"
 category: "language"

--- a/content/language/markdown-javadoc-comments.yaml
+++ b/content/language/markdown-javadoc-comments.yaml
@@ -1,5 +1,5 @@
 ---
-id: 92
+id: 6ffd6f18-9209-485f-b741-a973092b98a2
 slug: "markdown-javadoc-comments"
 title: "Markdown in Javadoc comments"
 category: "language"

--- a/content/language/module-import-declarations.yaml
+++ b/content/language/module-import-declarations.yaml
@@ -1,5 +1,5 @@
 ---
-id: 17
+id: c725a785-d4e2-41c6-8ca8-9bfde8588926
 slug: "module-import-declarations"
 title: "Module import declarations"
 category: "language"

--- a/content/language/pattern-matching-instanceof.yaml
+++ b/content/language/pattern-matching-instanceof.yaml
@@ -1,5 +1,5 @@
 ---
-id: 4
+id: a3a86fc1-adb0-4715-9847-11e68efa117f
 slug: "pattern-matching-instanceof"
 title: "Pattern matching for instanceof"
 category: "language"

--- a/content/language/pattern-matching-switch.yaml
+++ b/content/language/pattern-matching-switch.yaml
@@ -1,5 +1,5 @@
 ---
-id: 14
+id: 712b1e93-5fad-47f4-a6d9-9d42bbbd2ae7
 slug: "pattern-matching-switch"
 title: "Pattern matching in switch"
 category: "language"

--- a/content/language/primitive-types-in-patterns.yaml
+++ b/content/language/primitive-types-in-patterns.yaml
@@ -1,5 +1,5 @@
 ---
-id: 16
+id: b8c1f34e-1d3d-46c7-a5bc-7279f1069537
 slug: "primitive-types-in-patterns"
 title: "Primitive types in patterns"
 category: "language"

--- a/content/language/private-interface-methods.yaml
+++ b/content/language/private-interface-methods.yaml
@@ -1,5 +1,5 @@
 ---
-id: 13
+id: bd626f9b-c4d8-4004-913e-4613fb958e14
 slug: "private-interface-methods"
 title: "Private interface methods"
 category: "language"

--- a/content/language/record-patterns.yaml
+++ b/content/language/record-patterns.yaml
@@ -1,5 +1,5 @@
 ---
-id: 7
+id: eeace38f-2b4d-441b-b7ee-92b6a5d2658c
 slug: "record-patterns"
 title: "Record patterns (destructuring)"
 category: "language"

--- a/content/language/records-for-data-classes.yaml
+++ b/content/language/records-for-data-classes.yaml
@@ -1,5 +1,5 @@
 ---
-id: 5
+id: 9cf3d86f-eb07-4056-9d72-9a8443b47b83
 slug: "records-for-data-classes"
 title: "Records for data classes"
 category: "language"

--- a/content/language/sealed-classes.yaml
+++ b/content/language/sealed-classes.yaml
@@ -1,5 +1,5 @@
 ---
-id: 6
+id: 89fe2c46-7b17-4a79-94ec-f3d6dc72c1ed
 slug: "sealed-classes"
 title: "Sealed classes for type hierarchies"
 category: "language"

--- a/content/language/static-members-in-inner-classes.yaml
+++ b/content/language/static-members-in-inner-classes.yaml
@@ -1,5 +1,5 @@
 ---
-id: 94
+id: 3367a86f-5e67-4edd-b668-c547d4fb462b
 slug: "static-members-in-inner-classes"
 title: "Static members in inner classes"
 category: "language"

--- a/content/language/static-methods-in-interfaces.yaml
+++ b/content/language/static-methods-in-interfaces.yaml
@@ -1,5 +1,5 @@
 ---
-id: 93
+id: 413bcef8-2ec4-444f-9b70-a6f6af2c8c55
 slug: "static-methods-in-interfaces"
 title: "Static methods in interfaces"
 category: "language"

--- a/content/language/switch-expressions.yaml
+++ b/content/language/switch-expressions.yaml
@@ -1,5 +1,5 @@
 ---
-id: 3
+id: 078a3160-0074-4206-82f6-9050c9dcb2da
 slug: "switch-expressions"
 title: "Switch expressions"
 category: "language"

--- a/content/language/text-blocks-for-multiline-strings.yaml
+++ b/content/language/text-blocks-for-multiline-strings.yaml
@@ -1,5 +1,5 @@
 ---
-id: 2
+id: fb6fa907-c2f1-4265-bac7-4eb5370afe23
 slug: "text-blocks-for-multiline-strings"
 title: "Text blocks for multiline strings"
 category: "language"

--- a/content/language/type-inference-with-var.yaml
+++ b/content/language/type-inference-with-var.yaml
@@ -1,5 +1,5 @@
 ---
-id: 1
+id: 01683189-5597-4dca-8cf8-7719357f5a37
 slug: "type-inference-with-var"
 title: "Type inference with var"
 category: "language"

--- a/content/language/unnamed-variables.yaml
+++ b/content/language/unnamed-variables.yaml
@@ -1,5 +1,5 @@
 ---
-id: 8
+id: 9dd3433c-3e3d-4948-a3e2-977b8a5ac29d
 slug: "unnamed-variables"
 title: "Unnamed variables with _"
 category: "language"

--- a/content/security/key-derivation-functions.yaml
+++ b/content/security/key-derivation-functions.yaml
@@ -1,5 +1,5 @@
 ---
-id: 77
+id: 1d281f7a-1bf1-45b9-b86f-b6bf904b64ef
 slug: "key-derivation-functions"
 title: "Key Derivation Functions"
 category: "security"

--- a/content/security/pem-encoding.yaml
+++ b/content/security/pem-encoding.yaml
@@ -1,5 +1,5 @@
 ---
-id: 76
+id: adc174c1-0461-4706-add8-a039cf395cc3
 slug: "pem-encoding"
 title: "PEM encoding/decoding"
 category: "security"

--- a/content/security/random-generator.yaml
+++ b/content/security/random-generator.yaml
@@ -1,5 +1,5 @@
 ---
-id: 89
+id: f88bc5e9-5118-4ab8-bd29-910964cf4d20
 slug: "random-generator"
 title: "RandomGenerator interface"
 category: "security"

--- a/content/security/strong-random.yaml
+++ b/content/security/strong-random.yaml
@@ -1,5 +1,5 @@
 ---
-id: 78
+id: f5c9394d-eb6e-404d-a720-abe96f172179
 slug: "strong-random"
 title: "Strong random generation"
 category: "security"

--- a/content/security/tls-default.yaml
+++ b/content/security/tls-default.yaml
@@ -1,5 +1,5 @@
 ---
-id: 79
+id: 691d840e-33da-4a8b-b512-eb500ec3d294
 slug: "tls-default"
 title: "TLS 1.3 by default"
 category: "security"

--- a/content/streams/collectors-flatmapping.yaml
+++ b/content/streams/collectors-flatmapping.yaml
@@ -1,5 +1,5 @@
 ---
-id: 39
+id: 18644872-5dff-481b-9c0f-a8399c09276a
 slug: "collectors-flatmapping"
 title: "Collectors.flatMapping()"
 category: "streams"

--- a/content/streams/optional-ifpresentorelse.yaml
+++ b/content/streams/optional-ifpresentorelse.yaml
@@ -1,5 +1,5 @@
 ---
-id: 44
+id: 7999b44d-3a03-4bcc-aac4-4eaf56632c32
 slug: "optional-ifpresentorelse"
 title: "Optional.ifPresentOrElse()"
 category: "streams"

--- a/content/streams/optional-or.yaml
+++ b/content/streams/optional-or.yaml
@@ -1,5 +1,5 @@
 ---
-id: 45
+id: 22b5ff6c-8f28-47c9-ab71-8fbc82791878
 slug: "optional-or"
 title: "Optional.or() fallback"
 category: "streams"

--- a/content/streams/predicate-not.yaml
+++ b/content/streams/predicate-not.yaml
@@ -1,5 +1,5 @@
 ---
-id: 87
+id: 1419eeaf-2277-4aad-bde8-d7c1a1c3c593
 slug: "predicate-not"
 title: "Predicate.not() for negation"
 category: "streams"

--- a/content/streams/stream-gatherers.yaml
+++ b/content/streams/stream-gatherers.yaml
@@ -1,5 +1,5 @@
 ---
-id: 42
+id: 6e35dedb-7344-4e0c-a946-cea209414956
 slug: "stream-gatherers"
 title: "Stream gatherers"
 category: "streams"

--- a/content/streams/stream-iterate-predicate.yaml
+++ b/content/streams/stream-iterate-predicate.yaml
@@ -1,5 +1,5 @@
 ---
-id: 37
+id: 963d295f-188b-45b8-9fbb-c64cbc36958c
 slug: "stream-iterate-predicate"
 title: "Stream.iterate() with predicate"
 category: "streams"

--- a/content/streams/stream-mapmulti.yaml
+++ b/content/streams/stream-mapmulti.yaml
@@ -1,5 +1,5 @@
 ---
-id: 41
+id: b1b9448b-4531-4af3-ba3c-0093e4bf4eed
 slug: "stream-mapmulti"
 title: "Stream.mapMulti()"
 category: "streams"

--- a/content/streams/stream-of-nullable.yaml
+++ b/content/streams/stream-of-nullable.yaml
@@ -1,5 +1,5 @@
 ---
-id: 36
+id: fcc00b36-4542-4f58-8c2f-6bfee8362826
 slug: "stream-of-nullable"
 title: "Stream.ofNullable()"
 category: "streams"

--- a/content/streams/stream-takewhile-dropwhile.yaml
+++ b/content/streams/stream-takewhile-dropwhile.yaml
@@ -1,5 +1,5 @@
 ---
-id: 38
+id: 6f1e7cff-996f-484e-8aeb-039e21e39700
 slug: "stream-takewhile-dropwhile"
 title: "Stream takeWhile / dropWhile"
 category: "streams"

--- a/content/streams/stream-tolist.yaml
+++ b/content/streams/stream-tolist.yaml
@@ -1,5 +1,5 @@
 ---
-id: 40
+id: 26adb984-adea-46f1-b766-31c1246c66b1
 slug: "stream-tolist"
 title: "Stream.toList()"
 category: "streams"

--- a/content/streams/virtual-thread-executor.yaml
+++ b/content/streams/virtual-thread-executor.yaml
@@ -1,5 +1,5 @@
 ---
-id: 43
+id: e1e93294-e581-4d1c-aee8-af5dde8833a2
 slug: "virtual-thread-executor"
 title: "Virtual thread executor"
 category: "streams"

--- a/content/strings/string-chars-stream.yaml
+++ b/content/strings/string-chars-stream.yaml
@@ -1,5 +1,5 @@
 ---
-id: 35
+id: 8fe15a96-160e-45de-bfd0-e1ad1726d5c4
 slug: "string-chars-stream"
 title: "String chars as stream"
 category: "strings"

--- a/content/strings/string-formatted.yaml
+++ b/content/strings/string-formatted.yaml
@@ -1,5 +1,5 @@
 ---
-id: 33
+id: 1c85a064-8bc5-41df-89df-f98f8b7da370
 slug: "string-formatted"
 title: "String.formatted()"
 category: "strings"

--- a/content/strings/string-indent-transform.yaml
+++ b/content/strings/string-indent-transform.yaml
@@ -1,5 +1,5 @@
 ---
-id: 32
+id: ff92e3b3-3067-415b-9691-72b5097e0135
 slug: "string-indent-transform"
 title: "String.indent() and transform()"
 category: "strings"

--- a/content/strings/string-isblank.yaml
+++ b/content/strings/string-isblank.yaml
@@ -1,5 +1,5 @@
 ---
-id: 29
+id: 72013dbb-bf60-4536-9c25-8f874a6b66b4
 slug: "string-isblank"
 title: "String.isBlank()"
 category: "strings"

--- a/content/strings/string-lines.yaml
+++ b/content/strings/string-lines.yaml
@@ -1,5 +1,5 @@
 ---
-id: 86
+id: 125c95a2-7a37-4a32-9ee4-4c7d12ef63b7
 slug: "string-lines"
 title: "String.lines() for line splitting"
 category: "strings"

--- a/content/strings/string-repeat.yaml
+++ b/content/strings/string-repeat.yaml
@@ -1,5 +1,5 @@
 ---
-id: 31
+id: 4fdd8368-8dbe-4cb4-b1de-89bb98bc47db
 slug: "string-repeat"
 title: "String.repeat()"
 category: "strings"

--- a/content/strings/string-strip.yaml
+++ b/content/strings/string-strip.yaml
@@ -1,5 +1,5 @@
 ---
-id: 30
+id: 863a1b00-ee36-4b89-af38-d888ceb955ef
 slug: "string-strip"
 title: "String.strip() vs trim()"
 category: "strings"

--- a/content/template.json
+++ b/content/template.json
@@ -1,5 +1,5 @@
 {
-  "id": 0,
+  "id": "replace-with-a-new-uuid",
   "slug": "your-slug-here",
   "title": "Your Pattern Title",
   "category": "language",

--- a/content/tooling/aot-class-preloading.yaml
+++ b/content/tooling/aot-class-preloading.yaml
@@ -1,5 +1,5 @@
 ---
-id: 85
+id: aaed81eb-f945-497e-b7eb-85c0962f1fe9
 slug: "aot-class-preloading"
 title: "AOT class preloading"
 category: "tooling"

--- a/content/tooling/built-in-http-server.yaml
+++ b/content/tooling/built-in-http-server.yaml
@@ -1,5 +1,5 @@
 ---
-id: 91
+id: 019a8c37-225e-404c-a9a5-af4d50af06a3
 slug: "built-in-http-server"
 title: "Built-in HTTP server"
 category: "tooling"

--- a/content/tooling/compact-object-headers.yaml
+++ b/content/tooling/compact-object-headers.yaml
@@ -1,5 +1,5 @@
 ---
-id: 84
+id: 8369861b-2035-450c-b9c7-e882b1e0fc14
 slug: "compact-object-headers"
 title: "Compact object headers"
 category: "tooling"

--- a/content/tooling/jfr-profiling.yaml
+++ b/content/tooling/jfr-profiling.yaml
@@ -1,5 +1,5 @@
 ---
-id: 83
+id: b20cf15e-8d39-4e3d-be23-d91b281fb3fd
 slug: "jfr-profiling"
 title: "JFR for profiling"
 category: "tooling"

--- a/content/tooling/jshell-prototyping.yaml
+++ b/content/tooling/jshell-prototyping.yaml
@@ -1,5 +1,5 @@
 ---
-id: 80
+id: 3aaba7e8-bd12-441a-b104-049feaa104b6
 slug: "jshell-prototyping"
 title: "JShell for prototyping"
 category: "tooling"

--- a/content/tooling/junit6-with-jspecify.yaml
+++ b/content/tooling/junit6-with-jspecify.yaml
@@ -1,5 +1,5 @@
 ---
-id: 111
+id: 7b2ab276-c79f-4aa9-b6e0-9f560436e936
 slug: "junit6-with-jspecify"
 title: "JUnit 6 with JSpecify null safety"
 category: "tooling"

--- a/content/tooling/multi-file-source.yaml
+++ b/content/tooling/multi-file-source.yaml
@@ -1,5 +1,5 @@
 ---
-id: 82
+id: 327ea5da-b0cd-442a-b3ac-613176285f95
 slug: "multi-file-source"
 title: "Multi-file source launcher"
 category: "tooling"

--- a/content/tooling/single-file-execution.yaml
+++ b/content/tooling/single-file-execution.yaml
@@ -1,5 +1,5 @@
 ---
-id: 81
+id: 50fec359-09d8-4ae1-9d22-bf5b97b6b9e2
 slug: "single-file-execution"
 title: "Single-file execution"
 category: "tooling"

--- a/html-generators/generate.java
+++ b/html-generators/generate.java
@@ -145,6 +145,7 @@ static final Set<String> EXCLUDED_KEYS = Set.of("_path", "prev", "next", "relate
 
 record Snippet(JsonNode node) {
     String get(String f)    { return node.get(f).asText(); }
+    String id()             { return get("id"); }
     String slug()           { return get("slug"); }
     String category()       { return get("category"); }
     String title()          { return get("title"); }
@@ -331,6 +332,7 @@ void buildLocale(String locale, Templates templates, SequencedMap<String, Snippe
 
 SequencedMap<String, Snippet> loadAllSnippets() throws IOException {
     SequencedMap<String, Snippet> snippets = new LinkedHashMap<>();
+    var ids = new HashSet<String>();
     for (var cat : CATEGORY_DISPLAY.sequencedKeySet()) {
         var catDir = Path.of(CONTENT_DIR, cat);
         if (!Files.isDirectory(catDir)) continue;
@@ -346,11 +348,33 @@ SequencedMap<String, Snippet> loadAllSnippets() throws IOException {
             var filename = path.getFileName().toString();
             var ext = filename.substring(filename.lastIndexOf('.') + 1);
             var json = MAPPERS.get(ext).readTree(Files.readString(path));
+            var id = requireUuidId(json, path);
+            if (!ids.add(id)) {
+                throw new IllegalArgumentException("Duplicate UUID id \"" + id + "\" in " + path);
+            }
             var snippet = new Snippet(json);
             snippets.put(snippet.key(), snippet);
         }
     }
     return snippets;
+}
+
+String requireUuidId(JsonNode node, Path path) {
+    var idNode = node.get("id");
+    if (idNode == null || !idNode.isTextual()) {
+        throw new IllegalArgumentException("Missing or non-string UUID id in " + path);
+    }
+
+    var id = idNode.asText().strip();
+    try {
+        var parsed = UUID.fromString(id);
+        if (!parsed.toString().equals(id)) {
+            throw new IllegalArgumentException("UUID id must use canonical lowercase form");
+        }
+        return id;
+    } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Invalid UUID id \"" + id + "\" in " + path, e);
+    }
 }
 
 String escape(String text) {
@@ -638,7 +662,7 @@ static final Set<String> TRANSLATABLE_FIELDS = Set.of(
 /**
  * Overlay translated content onto the English base.
  * Translation files contain only translatable fields; everything else
- * (id, slug, category, difficulty, code, navigation, docs, etc.)
+ * (UUID id, slug, category, difficulty, code, navigation, docs, etc.)
  * is always taken from the English source of truth.
  */
 Snippet resolveSnippet(Snippet englishSnippet, String locale) {

--- a/html-generators/og/ContentLoader.java
+++ b/html-generators/og/ContentLoader.java
@@ -9,9 +9,11 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.SequencedMap;
+import java.util.UUID;
 
 /** Loads content JSON/YAML files and category properties. */
 public final class ContentLoader {
@@ -45,6 +47,7 @@ public final class ContentLoader {
 
     public static SequencedMap<String, Snippet> loadAllSnippets() throws IOException {
         var snippets = new LinkedHashMap<String, Snippet>();
+        var ids = new HashSet<String>();
         for (var cat : CATEGORY_DISPLAY.sequencedKeySet()) {
             var catDir = Path.of(CONTENT_DIR, cat);
             if (!Files.isDirectory(catDir)) continue;
@@ -58,11 +61,34 @@ public final class ContentLoader {
             for (var path : sorted) {
                 var ext = path.getFileName().toString();
                 ext = ext.substring(ext.lastIndexOf('.') + 1);
-                var snippet = new Snippet(MAPPERS.get(ext).readTree(Files.readString(path)));
+                var node = MAPPERS.get(ext).readTree(Files.readString(path));
+                var id = requireUuidId(node, path);
+                if (!ids.add(id)) {
+                    throw new IllegalArgumentException("Duplicate UUID id \"" + id + "\" in " + path);
+                }
+                var snippet = new Snippet(node);
                 snippets.put(snippet.key(), snippet);
             }
         }
         return snippets;
+    }
+
+    static String requireUuidId(JsonNode node, Path path) {
+        var idNode = node.get("id");
+        if (idNode == null || !idNode.isTextual()) {
+            throw new IllegalArgumentException("Missing or non-string UUID id in " + path);
+        }
+
+        var id = idNode.asText().strip();
+        try {
+            var parsed = UUID.fromString(id);
+            if (!parsed.toString().equals(id)) {
+                throw new IllegalArgumentException("UUID id must use canonical lowercase form");
+            }
+            return id;
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid UUID id \"" + id + "\" in " + path, e);
+        }
     }
 
     public static SequencedMap<String, String> loadProperties(String file) {


### PR DESCRIPTION
Numeric pattern IDs require centralized sequencing and have already produced collisions when patterns are added in parallel. UUIDs let contributors create independent patterns without coordinating identifier allocation.

- Migrates all 114 existing pattern IDs to unique UUIDs.
- Validates canonical UUID format and uniqueness in both site generators.
- Updates the content template and contributor instructions to generate UUIDs for new patterns.

Validation: generated all localized site content successfully and compiled the OG generator.