### PR TITLE
Add java.net.http WebSocket client pattern

### DIFF
--- a/content/io/http-client.yaml
+++ b/content/io/http-client.yaml
@@ -43,7 +43,7 @@ support:
   state: "available"
   description: "Widely available since JDK 11 (Sept 2018)"
 prev: "concurrency/lock-free-lazy-init"
-next: "io/io-class-console-io"
+next: "io/http-websocket-client"
 related:
 - "io/reading-files"
 - "io/inputstream-transferto"

--- a/content/io/http-websocket-client.yaml
+++ b/content/io/http-websocket-client.yaml
@@ -1,0 +1,65 @@
+---
+id: 115
+slug: "http-websocket-client"
+title: "WebSocket clients with java.net.http"
+category: "io"
+difficulty: "intermediate"
+jdkVersion: "11"
+oldLabel: "Third-party library"
+modernLabel: "Java 11+"
+oldApproach: "Third-party WebSocket client"
+modernApproach: "java.net.http.WebSocket"
+oldCode: |-
+  WebSocketClient client =
+      new WebSocketClient(serverUri) {
+          @Override
+          public void onMessage(String message) {
+              handle(message);
+          }
+      };
+  client.connect();
+modernCode: |-
+  HttpClient.newHttpClient()
+      .newWebSocketBuilder()
+      .buildAsync(serverUri,
+          new WebSocket.Listener() {
+              @Override
+              public CompletionStage<?> onText(
+                      WebSocket socket,
+                      CharSequence data,
+                      boolean last) {
+                  handle(data.toString());
+                  return WebSocket.Listener.super
+                      .onText(socket, data, last);
+              }
+          });
+summary: "Use the standard asynchronous WebSocket client instead of adding a third-party dependency."
+explanation: "The java.net.http package includes an asynchronous WebSocket client integrated with the standard HTTP client. Connections are established with CompletableFuture, listener callbacks support non-blocking message processing through CompletionStage, and the client shares the JDK's standard proxy, TLS, and executor configuration."
+whyModernWins:
+- icon: "📦"
+  title: "No extra dependency"
+  desc: "The WebSocket client ships with the JDK."
+- icon: "🧵"
+  title: "Asynchronous API"
+  desc: "Connection and message handling compose with CompletionStage."
+- icon: "🔗"
+  title: "Shared HTTP stack"
+  desc: "Proxy, TLS, and executor configuration use standard JDK facilities."
+support:
+  state: "available"
+  description: "Widely available since JDK 11 (September 2018)"
+prev: "io/http-client"
+next: "io/io-class-console-io"
+related:
+- "io/http-client"
+- "concurrency/completablefuture-chaining"
+- "concurrency/concurrent-http-virtual"
+tags:
+- http
+- io
+- async
+docs:
+- title: "WebSocket"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.net.http/java/net/http/WebSocket.html"
+- title: "HTTP Client (JEP 321)"
+  href: "https://openjdk.org/jeps/321"

--- a/content/io/http-websocket-client.yaml
+++ b/content/io/http-websocket-client.yaml
@@ -1,5 +1,5 @@
 ---
-id: 115
+id: "efd29a06-ffe7-4c3e-ba0f-627eee35b1a2"
 slug: "http-websocket-client"
 title: "WebSocket clients with java.net.http"
 category: "io"

--- a/content/io/io-class-console-io.yaml
+++ b/content/io/io-class-console-io.yaml
@@ -43,7 +43,7 @@ whyModernWins:
 support:
   state: "available"
   description: "Finalized in JDK 25 alongside compact source files (JEP 512)"
-prev: "io/http-client"
+prev: "io/http-websocket-client"
 next: "io/reading-files"
 related:
 - "language/compact-source-files"

--- a/proof/io/HttpWebsocketClient.java
+++ b/proof/io/HttpWebsocketClient.java
@@ -1,0 +1,33 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 25+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.util.concurrent.CompletionStage;
+
+/// Proof: http-websocket-client
+/// Source: content/io/http-websocket-client.yaml
+void main() {
+    URI serverUri = URI.create("wss://example.com/socket");
+
+    // Keep this compilation proof from opening a network connection.
+    if (false) {
+        HttpClient.newHttpClient()
+            .newWebSocketBuilder()
+            .buildAsync(serverUri,
+                new WebSocket.Listener() {
+                    @Override
+                    public CompletionStage<?> onText(
+                            WebSocket socket,
+                            CharSequence data,
+                            boolean last) {
+                        handle(data.toString());
+                        return WebSocket.Listener.super
+                            .onText(socket, data, last);
+                    }
+                });
+    }
+}
+
+void handle(String message) {
+}


### PR DESCRIPTION
Java developers can use the JDK's standard asynchronous WebSocket client instead of introducing a third-party client dependency.

This adds an intermediate Java 11 pattern comparing the two approaches, links it into the I/O navigation chain beside the existing HTTP client pattern, and includes a compile proof for the modern `WebSocket.Listener` example. The pattern uses the repository's UUID ID schema and existing `http`, `io`, and `async` topics.

Fixes: #183