### PR TITLE
Add Locale.of modernization pattern

### DIFF
--- a/content/datetime/hex-format.yaml
+++ b/content/datetime/hex-format.yaml
@@ -41,7 +41,7 @@ support:
   state: "available"
   description: "Widely available since JDK 17 LTS (Sept 2021)"
 prev: "datetime/math-clamp"
-next: "security/pem-encoding"
+next: "datetime/locale-of"
 related:
 - "datetime/date-formatting"
 - "datetime/instant-precision"

--- a/content/datetime/locale-of.yaml
+++ b/content/datetime/locale-of.yaml
@@ -1,5 +1,5 @@
 ---
-id: 115
+id: 361b53ba-ec9d-45a1-95e5-8c4b3aa7731a
 slug: "locale-of"
 title: "Locale constructors to Locale.of()"
 category: "datetime"

--- a/content/datetime/locale-of.yaml
+++ b/content/datetime/locale-of.yaml
@@ -1,0 +1,45 @@
+---
+id: 115
+slug: "locale-of"
+title: "Locale constructors to Locale.of()"
+category: "datetime"
+difficulty: "beginner"
+jdkVersion: "19"
+oldLabel: "Deprecated constructor"
+modernLabel: "Java 19+"
+oldApproach: "Locale constructors"
+modernApproach: "Locale.of()"
+oldCode: |-
+  Locale brazilianPortuguese =
+      new Locale("pt", "BR");
+modernCode: |-
+  Locale brazilianPortuguese =
+      Locale.of("pt", "BR");
+summary: "Create language and region locales with Locale.of() instead of deprecated constructors."
+explanation: "Locale factory methods replace constructors deprecated in JDK 19. The factory\
+  \ form is clearer, aligns with other value-based APIs, and centralizes locale creation."
+whyModernWins:
+- icon: "✅"
+  title: "Supported API"
+  desc: "Avoids deprecated constructors."
+- icon: "👁"
+  title: "Clear construction"
+  desc: "The named factory communicates intent."
+- icon: "🧩"
+  title: "Consistent style"
+  desc: "Matches modern JDK value-object factories."
+support:
+  state: "available"
+  description: "Available since JDK 19 (September 2022)"
+prev: "datetime/hex-format"
+next: "security/pem-encoding"
+related:
+- "datetime/date-formatting"
+- "datetime/java-time-basics"
+- "strings/string-formatted"
+tags:
+- datetime
+- constructors
+docs:
+- title: "Locale.of()"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Locale.html#of(java.lang.String,java.lang.String)"

--- a/content/security/pem-encoding.yaml
+++ b/content/security/pem-encoding.yaml
@@ -39,7 +39,7 @@ whyModernWins:
 support:
   state: "preview"
   description: "Preview in JDK 25 (JEP 470). Requires --enable-preview."
-prev: "datetime/hex-format"
+prev: "datetime/locale-of"
 next: "security/key-derivation-functions"
 related:
 - "security/key-derivation-functions"

--- a/proof/datetime/LocaleOf.java
+++ b/proof/datetime/LocaleOf.java
@@ -1,0 +1,10 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 25+
+import java.util.Locale;
+
+/// Proof: locale-of
+/// Source: content/datetime/locale-of.yaml
+void main() {
+    Locale brazilianPortuguese =
+        Locale.of("pt", "BR");
+}


### PR DESCRIPTION
Java 19 deprecated the public `Locale` constructors in favor of named factory methods. This adds a beginner pattern showing how to replace `new Locale("pt", "BR")` with `Locale.of("pt", "BR")`.

The pattern is linked into the Date/Time navigation chain, includes relevant tags and Oracle documentation, and has a Java 25 JBang proof for the modern example. Its content ID follows the UUID schema now required by the generator.

Fixes: #182