### PR TITLE
Add modern synchronized collections pattern

### DIFF
--- a/content/collections/legacy-synchronized-collections.yaml
+++ b/content/collections/legacy-synchronized-collections.yaml
@@ -1,0 +1,48 @@
+---
+id: d54a4e9f-74b9-4579-84a3-2541fe7b4272
+slug: "legacy-synchronized-collections"
+title: "Legacy synchronized collections to modern alternatives"
+category: "collections"
+difficulty: "intermediate"
+jdkVersion: "5"
+oldLabel: "Legacy synchronized collection"
+modernLabel: "Concurrent Collections API"
+oldApproach: "Hashtable"
+modernApproach: "ConcurrentHashMap"
+oldCode: |-
+  Hashtable<String, Session> sessions = new Hashtable<>();
+  sessions.put(id, session);
+modernCode: |-
+  ConcurrentMap<String, Session> sessions = new ConcurrentHashMap<>();
+  sessions.put(id, session);
+summary: "Replace Vector and Hashtable with collections selected for actual mutability and concurrency needs."
+explanation: "Vector and Hashtable synchronize every operation through legacy APIs. Modern\
+  \ code should normally use ArrayList or HashMap for thread-confined data, and purpose-built\
+  \ concurrent collections when shared mutation is required."
+whyModernWins:
+- icon: "🎯"
+  title: "Intentional concurrency"
+  desc: "The chosen type documents whether sharing is expected."
+- icon: "⚡"
+  title: "Better scalability"
+  desc: "ConcurrentHashMap avoids a single table-wide lock for normal access."
+- icon: "🧩"
+  title: "Modern APIs"
+  desc: "Works naturally with current collection and concurrent-map operations."
+support:
+  state: "available"
+  description: "Widely available since JDK 5 (September 2004)"
+prev: "collections/unmodifiable-collectors"
+next: "strings/string-isblank"
+related:
+- "collections/immutable-map-creation"
+- "collections/copying-collections-immutably"
+- "concurrency/lock-free-lazy-init"
+tags:
+- collections
+- concurrency
+docs:
+- title: "ConcurrentHashMap"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/concurrent/ConcurrentHashMap.html"
+- title: "ConcurrentMap"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/concurrent/ConcurrentMap.html"

--- a/content/collections/unmodifiable-collectors.yaml
+++ b/content/collections/unmodifiable-collectors.yaml
@@ -36,7 +36,7 @@ support:
   state: "available"
   description: "Widely available since JDK 16 (March 2021)"
 prev: "collections/reverse-list-iteration"
-next: "strings/string-isblank"
+next: "collections/legacy-synchronized-collections"
 related:
 - "collections/immutable-map-creation"
 - "collections/immutable-set-creation"

--- a/content/strings/string-isblank.yaml
+++ b/content/strings/string-isblank.yaml
@@ -32,7 +32,7 @@ whyModernWins:
 support:
   state: "available"
   description: "Widely available since JDK 11 (Sept 2018)"
-prev: "collections/unmodifiable-collectors"
+prev: "collections/legacy-synchronized-collections"
 next: "strings/string-strip"
 related:
 - "strings/string-formatted"

--- a/proof/collections/LegacySynchronizedCollections.java
+++ b/proof/collections/LegacySynchronizedCollections.java
@@ -1,0 +1,16 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 25+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/// Proof: legacy-synchronized-collections
+/// Source: content/collections/legacy-synchronized-collections.yaml
+void main() {
+    String id = "session-1";
+    Session session = new Session();
+
+    ConcurrentMap<String, Session> sessions = new ConcurrentHashMap<>();
+    sessions.put(id, session);
+}
+
+record Session() {}


### PR DESCRIPTION
Legacy `Vector` and `Hashtable` APIs obscure whether data is actually shared and impose synchronization regardless of the application's needs. This adds guidance for selecting ordinary collections for thread-confined data and purpose-built concurrent collections for shared mutation.

## Summary

- contrasts `Hashtable` with `ConcurrentMap` and `ConcurrentHashMap`
- explains when `ArrayList` or `HashMap` is the better non-concurrent choice
- adds collection and concurrency metadata, related patterns, and official API references
- wires the pattern into the global previous/next navigation chain
- adds a Java 25 JBang proof for the modern example

## Validation

- `jbang proof/collections/LegacySynchronizedCollections.java`
- `jbang html-generators/generate.java`

Fixes: #180