### PR TITLE
Add collection bulk operations pattern

### DIFF
--- a/content/collections/collection-bulk-operations.yaml
+++ b/content/collections/collection-bulk-operations.yaml
@@ -1,0 +1,50 @@
+---
+id: 6a0d1711-a495-490e-a830-95087e092b69
+slug: "collection-bulk-operations"
+title: "Collection bulk operations instead of mutation loops"
+category: "collections"
+difficulty: "beginner"
+jdkVersion: "8"
+oldLabel: "Iterator mutation loop"
+modernLabel: "Java 8+"
+oldApproach: "Manual iterator removal"
+modernApproach: "Collection.removeIf()"
+oldCode: |-
+  for (Iterator<Order> it = orders.iterator(); it.hasNext();) {
+      if (it.next().cancelled()) {
+          it.remove();
+      }
+  }
+modernCode: |-
+  orders.removeIf(Order::cancelled);
+summary: "Use removeIf(), replaceAll(), and List.sort() for direct collection transformations."
+explanation: "Modern collection interfaces expose common mutations directly. Methods such as removeIf(), replaceAll(), and List.sort() replace control-flow-heavy loops with operations that state the intended transformation."
+whyModernWins:
+- icon: "👁"
+  title: "Clear intent"
+  desc: "The operation describes what changes, not how to iterate."
+- icon: "🐛"
+  title: "Safer mutation"
+  desc: "Avoids manual iterator-removal rules."
+- icon: "⚡"
+  title: "Less code"
+  desc: "Common transformations become a single expression."
+support:
+  state: "available"
+  description: "Available since JDK 8 (March 2014)"
+prev: "collections/stack-to-deque"
+next: null
+related:
+- "collections/reverse-list-iteration"
+- "collections/copying-collections-immutably"
+- "streams/predicate-not"
+tags:
+- collections
+- functional
+docs:
+- title: "Collection.removeIf()"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Collection.html#removeIf(java.util.function.Predicate)"
+- title: "List.replaceAll()"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/List.html#replaceAll(java.util.function.UnaryOperator)"
+- title: "List.sort()"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/List.html#sort(java.util.Comparator)"

--- a/content/collections/stack-to-deque.yaml
+++ b/content/collections/stack-to-deque.yaml
@@ -33,7 +33,7 @@ support:
   state: "available"
   description: "Available since JDK 6 (December 2006)"
 prev: "enterprise/spring-boot-mvc-config"
-next: null
+next: "collections/collection-bulk-operations"
 related:
 - "collections/sequenced-collections"
 - "collections/reverse-list-iteration"

--- a/proof/collections/CollectionBulkOperations.java
+++ b/proof/collections/CollectionBulkOperations.java
@@ -1,0 +1,16 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 25+
+import java.util.*;
+
+/// Proof: collection-bulk-operations
+/// Source: content/collections/collection-bulk-operations.yaml
+void main() {
+    List<Order> orders = new ArrayList<>(List.of(
+        new Order(false),
+        new Order(true)
+    ));
+
+    orders.removeIf(Order::cancelled);
+}
+
+record Order(boolean cancelled) {}


### PR DESCRIPTION
Manual iterator mutation loops obscure intent and require callers to follow iterator-removal rules correctly. This adds a beginner pattern showing how Java 8 collection bulk operations express the transformation directly.

## Summary

- compare manual iterator removal with `Collection.removeIf()`
- cover `replaceAll()` and `List.sort()` in the explanation and API references
- add a Java 25 JBang proof for the modern example
- append the pattern to the global navigation chain

## Validation

- `jbang proof/collections/CollectionBulkOperations.java`
- `jbang html-generators/generate.java`

Fixes: #176