### PR TITLE
Add atomic map update pattern

### DIFF
--- a/content/collections/legacy-synchronized-collections.yaml
+++ b/content/collections/legacy-synchronized-collections.yaml
@@ -33,7 +33,7 @@ support:
   state: "available"
   description: "Widely available since JDK 5 (September 2004)"
 prev: "collections/unmodifiable-collectors"
-next: "strings/string-isblank"
+next: "collections/map-compute-and-merge"
 related:
 - "collections/immutable-map-creation"
 - "collections/copying-collections-immutably"

--- a/content/collections/map-compute-and-merge.yaml
+++ b/content/collections/map-compute-and-merge.yaml
@@ -1,0 +1,56 @@
+---
+id: fe4cbd51-2be6-4d7b-86c5-0ce82ce9bf10
+slug: "map-compute-and-merge"
+title: "Atomic map updates with compute and merge"
+category: "collections"
+difficulty: "intermediate"
+jdkVersion: "8"
+oldLabel: "Manual lookup and update"
+modernLabel: "Java 8+"
+oldApproach: "get() + null check + put()"
+modernApproach: "computeIfAbsent()"
+oldCode: |-
+  List<String> values = groups.get(key);
+  if (values == null) {
+      values = new ArrayList<>();
+      groups.put(key, values);
+  }
+  values.add(value);
+modernCode: |-
+  groups.computeIfAbsent(key, ignored -> new ArrayList<>())
+          .add(value);
+summary: "Replace multi-step map lookup and mutation with computeIfAbsent(), compute(), and merge()."
+explanation: "Map computation methods combine lookup and update intent into one operation.\
+  \ Use computeIfAbsent() for lazy initialization, compute() when the new value depends\
+  \ on the existing value, and merge() to combine a supplied value with one already in\
+  \ the map. On concurrent map implementations, supported computations also avoid races\
+  \ caused by separate get() and put() calls."
+whyModernWins:
+- icon: "⚡"
+  title: "Fewer lookups"
+  desc: "Avoids repeated key access."
+- icon: "🧵"
+  title: "Better concurrency semantics"
+  desc: "Concurrent maps can perform supported updates atomically."
+- icon: "👁"
+  title: "Clear intent"
+  desc: "The initialization rule appears beside the access."
+support:
+  state: "available"
+  description: "Widely available since JDK 8 (March 2014)"
+prev: "collections/legacy-synchronized-collections"
+next: "strings/string-isblank"
+related:
+- "collections/legacy-synchronized-collections"
+- "collections/immutable-map-creation"
+- "concurrency/lock-free-lazy-init"
+tags:
+- collections
+- functional
+docs:
+- title: "Map.computeIfAbsent()"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Map.html#computeIfAbsent(K,java.util.function.Function)"
+- title: "Map.compute()"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Map.html#compute(K,java.util.function.BiFunction)"
+- title: "Map.merge()"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Map.html#merge(K,V,java.util.function.BiFunction)"

--- a/content/strings/string-isblank.yaml
+++ b/content/strings/string-isblank.yaml
@@ -32,7 +32,7 @@ whyModernWins:
 support:
   state: "available"
   description: "Widely available since JDK 11 (Sept 2018)"
-prev: "collections/legacy-synchronized-collections"
+prev: "collections/map-compute-and-merge"
 next: "strings/string-strip"
 related:
 - "strings/string-formatted"

--- a/proof/collections/MapComputeAndMerge.java
+++ b/proof/collections/MapComputeAndMerge.java
@@ -1,0 +1,14 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 25+
+import java.util.*;
+
+/// Proof: map-compute-and-merge
+/// Source: content/collections/map-compute-and-merge.yaml
+void main() {
+    Map<String, List<String>> groups = new HashMap<>();
+    String key = "language";
+    String value = "Java";
+
+    groups.computeIfAbsent(key, ignored -> new ArrayList<>())
+            .add(value);
+}


### PR DESCRIPTION
Map initialization and updates are often written as separate lookup, null-check, and mutation steps, obscuring intent and introducing races on shared maps.

This adds a collections pattern centered on `computeIfAbsent()`, with guidance for choosing `compute()` and `merge()` and precise concurrency semantics for concurrent map implementations. It also links the pattern into the global navigation chain and adds a Java 25 compilation proof for the modern example.

**Validation**
- `jbang proof/collections/MapComputeAndMerge.java`
- `jbang html-generators/generate.java`

Fixes: #178