### PR TITLE
Add standard Base64 encoding pattern

### DIFF
--- a/content/security/key-derivation-functions.yaml
+++ b/content/security/key-derivation-functions.yaml
@@ -45,7 +45,7 @@ whyModernWins:
 support:
   state: "available"
   description: "Finalized in JDK 25 LTS (JEP 510, Sept 2025)."
-prev: "security/pem-encoding"
+prev: "security/standard-base64"
 next: "security/strong-random"
 related:
 - "security/pem-encoding"

--- a/content/security/pem-encoding.yaml
+++ b/content/security/pem-encoding.yaml
@@ -40,7 +40,7 @@ support:
   state: "preview"
   description: "Preview in JDK 25 (JEP 470). Requires --enable-preview."
 prev: "datetime/locale-of"
-next: "security/key-derivation-functions"
+next: "security/standard-base64"
 related:
 - "security/key-derivation-functions"
 - "security/strong-random"

--- a/content/security/standard-base64.yaml
+++ b/content/security/standard-base64.yaml
@@ -1,0 +1,47 @@
+---
+id: bffeb48b-eda4-4cd1-966d-e401ba9e75a6
+slug: "standard-base64"
+title: "Standard Base64 encoding and decoding"
+category: "security"
+difficulty: "beginner"
+jdkVersion: "8"
+oldLabel: "Internal JDK API"
+modernLabel: "Java 8+"
+oldApproach: "sun.misc encoder"
+modernApproach: "Standard Base64 API"
+oldCode: |-
+  String encoded = new sun.misc.BASE64Encoder()
+      .encode(data);
+modernCode: |-
+  String encoded = Base64.getEncoder()
+      .encodeToString(data);
+summary: "Use java.util.Base64 instead of internal JDK classes or third-party codecs."
+explanation: "The standard Base64 API provides basic, URL-safe, and MIME encoders and\
+  \ decoders without relying on unsupported internal packages. Use getEncoder() and\
+  \ getDecoder() for standard Base64, or select the URL and MIME variants when the\
+  \ target format requires them."
+whyModernWins:
+- icon: "🛡️"
+  title: "Supported API"
+  desc: "Avoids inaccessible sun.misc implementation classes."
+- icon: "🧩"
+  title: "Complete variants"
+  desc: "Includes basic, URL-safe, and MIME encoders and decoders."
+- icon: "🚀"
+  title: "No dependency"
+  desc: "Encoding and decoding are built into the JDK."
+support:
+  state: "available"
+  description: "Widely available since JDK 8 (March 2014)."
+prev: "security/pem-encoding"
+next: "security/key-derivation-functions"
+related:
+- "security/pem-encoding"
+- "datetime/hex-format"
+- "strings/string-chars-stream"
+tags:
+- security
+- serialization
+docs:
+- title: "Base64"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Base64.html"

--- a/proof/security/StandardBase64.java
+++ b/proof/security/StandardBase64.java
@@ -1,0 +1,12 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 25+
+import java.util.Base64;
+
+/// Proof: standard-base64
+/// Source: content/security/standard-base64.yaml
+void main() {
+    byte[] data = "Java evolved".getBytes();
+
+    String encoded = Base64.getEncoder()
+        .encodeToString(data);
+}


### PR DESCRIPTION
Java developers should use the supported `java.util.Base64` API instead of internal JDK classes or third-party codecs for standard encoding and decoding.

This adds a beginner Java 8 pattern covering the standard, URL-safe, and MIME variants, places it beside the related PEM encoding content, and includes a compilable JBang proof for the modern example.

Fixes: #177