### PR TITLE
Add deterministic resource cleanup pattern

### DIFF
--- a/content/io/file-memory-mapping.yaml
+++ b/content/io/file-memory-mapping.yaml
@@ -52,7 +52,7 @@ whyModernWins:
 support:
   state: "available"
   description: "Available since JDK 22 (March 2024)"
-prev: "io/try-with-resources-effectively-final"
+prev: "io/finalizers-to-resource-cleanup"
 next: "io/files-mismatch"
 related:
 - "io/http-client"

--- a/content/io/finalizers-to-resource-cleanup.yaml
+++ b/content/io/finalizers-to-resource-cleanup.yaml
@@ -1,0 +1,79 @@
+---
+id: 45488112-44bc-4a75-a6c6-a69849147ded
+slug: "finalizers-to-resource-cleanup"
+title: "Finalizers to deterministic resource cleanup"
+category: "io"
+difficulty: "advanced"
+jdkVersion: "9"
+oldLabel: "Finalization"
+modernLabel: "Java 9+"
+oldApproach: "Override finalize()"
+modernApproach: "AutoCloseable and Cleaner"
+oldCode: |-
+  @Override
+  protected void finalize() throws Throwable {
+      nativeHandle.release();
+  }
+modernCode: |-
+  final class NativeResource implements AutoCloseable {
+      private static final Cleaner CLEANER = Cleaner.create();
+
+      private static final class State implements Runnable {
+          private final long handle;
+
+          State(long handle) {
+              this.handle = handle;
+          }
+
+          @Override
+          public void run() {
+              release(handle);
+          }
+      }
+
+      private final Cleaner.Cleanable cleanable;
+
+      NativeResource(long handle) {
+          cleanable = CLEANER.register(this, new State(handle));
+      }
+
+      @Override
+      public void close() {
+          cleanable.clean();
+      }
+  }
+summary: "Replace finalization with AutoCloseable and use Cleaner only as a defensive fallback."
+explanation: "Finalization is deprecated for removal and provides neither prompt cleanup\
+  \ nor reliable ordering. Implement AutoCloseable so callers can release resources deterministically\
+  \ with try-with-resources. For leaked resources, Cleaner can invoke the same idempotent\
+  \ cleanup action as a last resort; its action must not retain the registered object."
+whyModernWins:
+- icon: "⏱"
+  title: "Deterministic"
+  desc: "Try-with-resources releases resources at a known point."
+- icon: "🛡"
+  title: "Safer lifecycle"
+  desc: "Avoids finalizer resurrection and unpredictable ordering."
+- icon: "🧹"
+  title: "Defensive fallback"
+  desc: "Cleaner can recover leaked resources without overriding finalize()."
+support:
+  state: "available"
+  description: "Cleaner and finalization deprecation available since JDK 9 (September 2017)"
+prev: "io/try-with-resources-effectively-final"
+next: "io/file-memory-mapping"
+related:
+- "io/try-with-resources-effectively-final"
+- "io/file-memory-mapping"
+- "concurrency/executor-try-with-resources"
+tags:
+- io
+- native
+- migration
+docs:
+- title: "Cleaner"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/ref/Cleaner.html"
+- title: "AutoCloseable"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/AutoCloseable.html"
+- title: "JEP 421: Deprecate Finalization for Removal"
+  href: "https://openjdk.org/jeps/421"

--- a/content/io/try-with-resources-effectively-final.yaml
+++ b/content/io/try-with-resources-effectively-final.yaml
@@ -39,7 +39,7 @@ support:
   state: "available"
   description: "Widely available since JDK 9 (Sept 2017)"
 prev: "io/path-of"
-next: "io/file-memory-mapping"
+next: "io/finalizers-to-resource-cleanup"
 related:
 - "io/path-of"
 - "io/reading-files"

--- a/proof/io/FinalizersToResourceCleanup.java
+++ b/proof/io/FinalizersToResourceCleanup.java
@@ -1,0 +1,44 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 25+
+
+import java.lang.ref.Cleaner;
+
+/// Proof: finalizers-to-resource-cleanup
+/// Source: content/io/finalizers-to-resource-cleanup.yaml
+final class NativeResource implements AutoCloseable {
+    private static final Cleaner CLEANER = Cleaner.create();
+
+    private static final class State implements Runnable {
+        private final long handle;
+
+        State(long handle) {
+            this.handle = handle;
+        }
+
+        @Override
+        public void run() {
+            release(handle);
+        }
+    }
+
+    private final Cleaner.Cleanable cleanable;
+
+    NativeResource(long handle) {
+        cleanable = CLEANER.register(this, new State(handle));
+    }
+
+    private static void release(long handle) {
+        IO.println("Released native handle " + handle);
+    }
+
+    @Override
+    public void close() {
+        cleanable.clean();
+    }
+}
+
+void main() {
+    try (var resource = new NativeResource(42L)) {
+        IO.println("Using native resource");
+    }
+}


### PR DESCRIPTION
Finalization is deprecated for removal and cannot guarantee prompt or ordered cleanup. This adds a migration pattern showing deterministic resource management with `AutoCloseable`, while retaining `Cleaner` only as a defensive fallback for leaked resources.

The modern example isolates cleanup state in a static `Runnable` so the cleaner action does not retain the registered resource. It also adds a Java 25 proof and inserts the pattern next to the existing try-with-resources entry in the I/O navigation chain.

Fixes: #173