### PR TITLE
Add anonymous classes to lambdas pattern

### DIFF
--- a/content/language/anonymous-classes-to-lambdas.yaml
+++ b/content/language/anonymous-classes-to-lambdas.yaml
@@ -1,0 +1,49 @@
+---
+id: bbccea66-79bb-4bf9-80ea-e6bdd96a7bfc
+slug: "anonymous-classes-to-lambdas"
+title: "Anonymous classes to lambdas and method references"
+category: "language"
+difficulty: "beginner"
+jdkVersion: "8"
+oldLabel: "Anonymous class"
+modernLabel: "Java 8+"
+oldApproach: "Anonymous class"
+modernApproach: "Method reference"
+oldCode: |-
+  button.addActionListener(new ActionListener() {
+      @Override
+      public void actionPerformed(ActionEvent event) {
+          save(event);
+      }
+  });
+modernCode: |-
+  button.addActionListener(this::save);
+summary: "Replace single-method anonymous classes with concise lambdas and method references."
+explanation: "Functional interfaces can be implemented with lambdas or method references. This removes anonymous-class ceremony while preserving static typing and the same callback contract."
+whyModernWins:
+- icon: "⚡"
+  title: "Less boilerplate"
+  desc: "Removes the class declaration and override ceremony."
+- icon: "👁"
+  title: "Better readability"
+  desc: "Keeps attention on the operation being performed."
+- icon: "🔒"
+  title: "Still type-safe"
+  desc: "The compiler checks the target functional-interface signature."
+support:
+  state: "available"
+  description: "Available since JDK 8 (March 2014)."
+prev: "tooling/junit6-with-jspecify"
+next: "language/default-interface-methods"
+related:
+- "language/default-interface-methods"
+- "streams/predicate-not"
+- "collections/collection-bulk-operations"
+tags:
+- functional
+- interfaces
+docs:
+- title: "Lambda Expressions"
+  href: "https://dev.java/learn/lambdas/"
+- title: "Method References"
+  href: "https://dev.java/learn/lambdas/method-references/"

--- a/content/language/default-interface-methods.yaml
+++ b/content/language/default-interface-methods.yaml
@@ -55,7 +55,7 @@ whyModernWins:
 support:
   state: "available"
   description: "Available since JDK 8 (March 2014)."
-prev: "tooling/junit6-with-jspecify"
+prev: "language/anonymous-classes-to-lambdas"
 next: "language/markdown-javadoc-comments"
 related:
 - "language/private-interface-methods"

--- a/content/tooling/junit6-with-jspecify.yaml
+++ b/content/tooling/junit6-with-jspecify.yaml
@@ -88,7 +88,7 @@ support:
   state: "available"
   description: "Available since JUnit 6.0 (October 2025, requires Java 17+)"
 prev: "tooling/aot-class-preloading"
-next: "language/default-interface-methods"
+next: "language/anonymous-classes-to-lambdas"
 related:
 - "enterprise/spring-null-safety-jspecify"
 - "errors/helpful-npe"

--- a/proof/language/AnonymousClassesToLambdas.java
+++ b/proof/language/AnonymousClassesToLambdas.java
@@ -1,0 +1,16 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 25+
+import java.awt.event.*;
+
+/// Proof: anonymous-classes-to-lambdas
+/// Source: content/language/anonymous-classes-to-lambdas.yaml
+void save(ActionEvent event) {}
+
+void main() {
+    Button button = new Button();
+    button.addActionListener(this::save);
+}
+
+class Button {
+    void addActionListener(ActionListener listener) {}
+}


### PR DESCRIPTION
Java 8 functional interfaces let callbacks shed anonymous-class ceremony while retaining compile-time type safety. This adds the requested modernization pattern so readers can see the direct method-reference replacement and understand when lambdas apply.

The new pattern includes complete metadata, related topics, and official lambda and method-reference documentation. It is inserted into the reciprocal navigation chain before the existing default-interface-methods pattern, with a Java 25 proof that compiles the modern callback example.

Fixes: #181