### PR TITLE
Add standard Class-File API pattern

### DIFF
--- a/content/tooling/aot-class-preloading.yaml
+++ b/content/tooling/aot-class-preloading.yaml
@@ -41,7 +41,7 @@ support:
   state: "available"
   description: "Available as a standard feature in JDK 25 LTS (JEPs 514/515, Sept\
     \ 2025)."
-prev: "tooling/built-in-http-server"
+prev: "tooling/class-file-api"
 next: "tooling/junit6-with-jspecify"
 related:
 - "tooling/jshell-prototyping"

--- a/content/tooling/built-in-http-server.yaml
+++ b/content/tooling/built-in-http-server.yaml
@@ -52,7 +52,7 @@ support:
   state: "available"
   description: "Available since JDK 18 (March 2022)"
 prev: "tooling/compact-object-headers"
-next: "tooling/aot-class-preloading"
+next: "tooling/class-file-api"
 related:
 - "io/http-client"
 - "tooling/single-file-execution"

--- a/content/tooling/class-file-api.yaml
+++ b/content/tooling/class-file-api.yaml
@@ -1,0 +1,51 @@
+---
+id: 25fec0a0-53ed-4b30-b30c-6f5a80feb1c2
+slug: "class-file-api"
+title: "Class-file parsing with the standard API"
+category: "tooling"
+difficulty: "advanced"
+jdkVersion: "24"
+oldLabel: "Third-party bytecode parser"
+modernLabel: "Java 24+"
+oldApproach: "ASM ClassReader"
+modernApproach: "Class-File API"
+oldCode: |-
+  ClassReader reader = new ClassReader(
+          Files.readAllBytes(classFile));
+  reader.accept(visitor, 0);
+modernCode: |-
+  ClassModel model = ClassFile.of().parse(classFile);
+  model.methods().forEach(method ->
+          System.out.println(
+                  method.methodName().stringValue()));
+summary: "Use the standard Class-File API for class-file parsing and transformation."
+explanation: "The Class-File API, finalized in JDK 24, provides supported models and\
+  \ transformations for JVM class files. It tracks the class-file format with the JDK\
+  \ and removes the need for third-party libraries in many inspection and generation\
+  \ tasks."
+whyModernWins:
+- icon: "🛡"
+  title: "Supported API"
+  desc: "Ships and evolves with the JDK class-file format."
+- icon: "📦"
+  title: "Fewer dependencies"
+  desc: "Handles common bytecode tasks without an external library."
+- icon: "🧩"
+  title: "Composable models"
+  desc: "Parsing, building, and transformation share one API."
+support:
+  state: "available"
+  description: "Finalized in JDK 24 (JEP 484, March 2025)."
+prev: "tooling/built-in-http-server"
+next: "tooling/aot-class-preloading"
+related:
+- "tooling/aot-class-preloading"
+- "tooling/compact-object-headers"
+- "tooling/multi-file-source"
+tags:
+- tooling
+docs:
+- title: "ClassFile"
+  href: "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/lang/classfile/ClassFile.html"
+- title: "Class-File API (JEP 484)"
+  href: "https://openjdk.org/jeps/484"

--- a/proof/tooling/ClassFileApi.java
+++ b/proof/tooling/ClassFileApi.java
@@ -1,0 +1,26 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 25+
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/// Proof: class-file-api
+/// Source: content/tooling/class-file-api.yaml
+void main() throws Exception {
+    Path classFile = Files.createTempFile("ClassFileApi", ".class");
+    try (var compiledClass =
+            getClass().getResourceAsStream("ClassFileApi.class")) {
+        Files.copy(compiledClass, classFile,
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    try {
+        ClassModel model = ClassFile.of().parse(classFile);
+        model.methods().forEach(method ->
+                System.out.println(
+                        method.methodName().stringValue()));
+    } finally {
+        Files.delete(classFile);
+    }
+}


### PR DESCRIPTION
The JDK has provided a supported Class-File API since Java 24, removing the need for third-party bytecode libraries in many parsing and transformation workflows. This adds the requested advanced tooling pattern and makes that modernization path discoverable on java.evolved.

The pattern compares ASM-based parsing with `ClassFile.of().parse(Path)`, links the standard API and JEP 484 documentation, and integrates the page into the tooling navigation chain. A Java 25 JBang proof parses its own compiled class and enumerates method names without external dependencies.

**Validation**
- `jbang proof/tooling/ClassFileApi.java`
- `jbang html-generators/generate.java`

Fixes: #172