### PR TITLE
Fix OG generation on Java 25

### DIFF
--- a/html-generators/generateog.java
+++ b/html-generators/generateog.java
@@ -2,6 +2,7 @@
 //JAVA 25
 //DEPS com.fasterxml.jackson.core:jackson-databind:2.18.3
 //DEPS com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.3
+//DEPS org.yaml:snakeyaml:2.4
 //SOURCES og/Palette.java
 //SOURCES og/Layout.java
 //SOURCES og/ContentLoader.java


### PR DESCRIPTION
Recent content deployments fail during Open Graph image generation, preventing GitHub Pages from publishing the generated site and its current pattern count.

Pin SnakeYAML 2.4 in the OG generator, matching the main site generator and restoring YAML parsing on Java 25.