### PR TITLE
Improve homepage pattern discovery

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -210,6 +210,8 @@
 
     let activeCategory = null;
     let activeJdk = null;
+    let hasSelection = false;
+    let showingAll = false;
 
     // LTS cycle ranges: each entry covers all versions introduced since the previous LTS
     const LTS_RANGES = {
@@ -220,6 +222,17 @@
     };
 
     const noResultsMsg = document.getElementById('noResultsMessage');
+    const startMessage = document.getElementById('patternStartMessage');
+    const showAllButton = document.getElementById('showAllButton');
+    const isDiscoveryHome = !!showAllButton;
+    hasSelection = !isDiscoveryHome;
+
+    const updateShowAllButton = () => {
+      if (!showAllButton) return;
+      showAllButton.textContent = showingAll
+        ? showAllButton.dataset.hideLabel
+        : showAllButton.dataset.showLabel;
+    };
 
     const applyFilters = () => {
       let visibleCount = 0;
@@ -231,13 +244,17 @@
           const range = LTS_RANGES[activeJdk];
           matchesJdk = range && version >= range[0] && version <= range[1];
         }
-        const visible = matchesCategory && matchesJdk;
+        const visible = hasSelection && matchesCategory && matchesJdk;
         card.classList.toggle('filter-hidden', !visible);
         if (visible) visibleCount++;
       });
 
+      if (startMessage) {
+        startMessage.hidden = hasSelection;
+      }
+
       if (noResultsMsg) {
-        noResultsMsg.style.display = visibleCount === 0 ? '' : 'none';
+        noResultsMsg.style.display = hasSelection && visibleCount === 0 ? '' : 'none';
       }
 
       if (window.updateViewToggleState) {
@@ -246,7 +263,7 @@
     };
 
     // Generic helper to wire up a dropdown
-    const initDropdown = (dropdownEl, onSelect) => {
+    const initDropdown = (dropdownEl, dataAttribute, onSelect) => {
       if (!dropdownEl) return;
       const toggleBtn = dropdownEl.querySelector('.jdk-dropdown-toggle');
       const labelEl = dropdownEl.querySelector('.jdk-label');
@@ -298,7 +315,7 @@
       });
 
       return { closeDropdown, setActive: (value) => {
-        const target = list.querySelector(`li[data-filter="${value}"]`);
+        const target = list.querySelector(`li[data-${dataAttribute}="${value}"]`);
         if (target) {
           selectItem(target);
           toggleBtn.classList.toggle('has-filter', value !== 'all');
@@ -310,9 +327,12 @@
 
     // Category dropdown
     const categoryDropdown = document.getElementById('categoryDropdown');
-    const catDropdownCtrl = initDropdown(categoryDropdown, (li, toggleBtn) => {
+    const catDropdownCtrl = initDropdown(categoryDropdown, 'filter', (li, toggleBtn) => {
       const category = li.dataset.filter;
+      hasSelection = true;
       activeCategory = category !== 'all' ? category : null;
+      showingAll = !activeCategory && !activeJdk;
+      updateShowAllButton();
       toggleBtn.classList.toggle('has-filter', !!activeCategory);
       if (activeCategory) {
         history.replaceState(null, '', '#' + activeCategory);
@@ -324,23 +344,46 @@
 
     // JDK dropdown
     const jdkDropdown = document.getElementById('jdkDropdown');
-    initDropdown(jdkDropdown, (li, toggleBtn) => {
+    const jdkDropdownCtrl = initDropdown(jdkDropdown, 'jdk-filter', (li, toggleBtn) => {
       const version = li.dataset.jdkFilter;
+      hasSelection = true;
       activeJdk = version !== 'all' ? version : null;
+      showingAll = !activeCategory && !activeJdk;
+      updateShowAllButton();
       toggleBtn.classList.toggle('has-filter', !!activeJdk);
       applyFilters();
     });
 
+    if (showAllButton) {
+      showAllButton.addEventListener('click', () => {
+        activeCategory = null;
+        activeJdk = null;
+        if (catDropdownCtrl) catDropdownCtrl.setActive('all');
+        if (jdkDropdownCtrl) jdkDropdownCtrl.setActive('all');
+        history.replaceState(null, '', window.location.pathname + window.location.search);
+        showingAll = !showingAll;
+        hasSelection = showingAll;
+        updateShowAllButton();
+        applyFilters();
+      });
+    }
+
     // Apply filter from a given category string (or "all" / empty for no filter)
     const applyHashFilter = (category) => {
       if (category && catDropdownCtrl && catDropdownCtrl.setActive(category)) {
+        hasSelection = true;
         activeCategory = category;
+        showingAll = false;
+        updateShowAllButton();
         applyFilters();
         const section = document.getElementById('all-comparisons');
         if (section) section.scrollIntoView({ behavior: 'smooth' });
       } else if (catDropdownCtrl) {
         catDropdownCtrl.setActive('all');
         activeCategory = null;
+        hasSelection = !isDiscoveryHome;
+        showingAll = false;
+        updateShowAllButton();
         applyFilters();
       } else {
         // No filter dropdowns (e.g. topic pages) — show all cards
@@ -348,7 +391,7 @@
       }
     };
 
-    // On load, apply filter from URL hash or default to "All"
+    // On load, a category hash reveals its matches; otherwise keep the discovery state.
     applyHashFilter(window.location.hash.slice(1));
 
     // Also react to browser back/forward hash changes

--- a/site/styles.css
+++ b/site/styles.css
@@ -286,20 +286,6 @@ nav {
   margin: 0 auto;
 }
 
-.hero-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.8rem;
-  font-weight: 500;
-  color: var(--accent);
-  background: rgba(251, 146, 60, .1);
-  border: 1px solid rgba(251, 146, 60, .2);
-  padding: 5px 14px;
-  border-radius: 999px;
-  margin-bottom: 24px;
-}
-
 .hero h1 {
   font-size: clamp(2.2rem, 5vw, 3.4rem);
   font-weight: 800;
@@ -453,20 +439,6 @@ nav {
   margin-bottom: 12px;
 }
 
-.section-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.78rem;
-  font-weight: 500;
-  color: var(--accent);
-  background: rgba(251, 146, 60, .08);
-  border: 1px solid rgba(251, 146, 60, .15);
-  padding: 4px 12px;
-  border-radius: 999px;
-  margin-bottom: 16px;
-}
-
 /* ---------- Tips / Card Grid ---------- */
 .tips-grid {
   display: grid;
@@ -484,6 +456,62 @@ nav {
   padding: 3rem 1rem;
   font-size: 1.1rem;
   width: 100%;
+}
+
+.pattern-start-message {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 540px;
+  margin: 32px auto 0;
+  padding: 36px 24px;
+  text-align: center;
+  color: var(--text);
+  border: 1px dashed var(--border-light);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+
+.pattern-start-message[hidden] {
+  display: none;
+}
+
+.pattern-start-message p {
+  max-width: 42ch;
+  margin: 12px 0 0;
+  line-height: 1.6;
+}
+
+.pattern-start-icon {
+  color: var(--accent);
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.show-all-btn {
+  padding: 10px 20px;
+  color: var(--text);
+  font: inherit;
+  font-size: 0.88rem;
+  font-weight: 500;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all 0.25s;
+}
+
+.show-all-btn:hover {
+  transform: translateY(-2px);
+  background: var(--surface-2);
+  border-color: var(--border-light);
+}
+
+.show-all-btn:focus-visible,
+.jdk-dropdown-toggle:focus-visible,
+.view-toggle-btn:focus-visible {
+  outline: 3px solid var(--blue);
+  outline-offset: 3px;
 }
 
 .tip-card {
@@ -695,6 +723,7 @@ nav {
 /* ---------- View Toggle Button ---------- */
 .view-toggle-wrap {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
   gap: 10px;
@@ -2086,8 +2115,11 @@ footer a:hover {
   margin-bottom: 8px;
 }
 .copilot-icon {
-  font-size: 1.8rem;
+  width: 36px;
+  height: 36px;
   flex-shrink: 0;
+  color: var(--text);
+  fill: currentColor;
 }
 .copilot-callout-text {
   flex: 1;
@@ -2101,18 +2133,23 @@ footer a:hover {
   flex-shrink: 0;
 }
 .copilot-callout-links a {
+  display: inline-flex;
+  align-items: center;
   white-space: nowrap;
-  padding: 8px 16px;
-  border-radius: 8px;
-  background: var(--accent);
-  color: #fff;
-  font-size: 0.85rem;
+  padding: 5px 10px;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  background: var(--surface-2);
+  color: var(--text-muted);
+  font-size: 0.8rem;
   font-weight: 600;
   text-decoration: none;
-  transition: opacity 0.2s;
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
 }
 .copilot-callout-links a:hover {
-  opacity: 0.85;
+  color: var(--blue);
+  border-color: var(--blue);
+  background: var(--surface);
 }
 @media (max-width: 640px) {
   .copilot-callout-inner {
@@ -2121,7 +2158,7 @@ footer a:hover {
   }
   .copilot-callout-links {
     flex-direction: column;
-    width: 100%;
+    align-self: center;
   }
   .copilot-callout-links a {
     text-align: center;
@@ -2165,8 +2202,13 @@ footer a:hover {
   border-color: var(--accent);
   color: #fff;
 }
-.share-li { font-family: Georgia, serif; font-weight: 800; font-size: 0.85rem; }
-.share-reddit { font-size: 1.1rem; }
+.share-li svg,
+.share-bsky svg,
+.share-reddit svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
 
 /* ============================
    Contribute Dropdown

--- a/templates/index.html
+++ b/templates/index.html
@@ -199,7 +199,6 @@
   </nav>
 
   <section class="hero">
-    <div class="hero-badge">{{site.heroSnippetCount}}</div>
     <h1>{{site.tagline_line1}}<br><span class="gradient">{{site.tagline_line2}}</span></h1>
     <p>{{site.description}}</p>
     <div class="hero-actions">
@@ -227,21 +226,35 @@
   <div class="social-share" id="socialShare">
     <span class="share-label">{{share.label}}</span>
     <a href="https://x.com/intent/tweet?url=https%3A%2F%2Fjavaevolved.github.io&text=java.evolved%20%E2%80%93%20Every%20old%20Java%20pattern%20next%20to%20its%20modern%20replacement%2C%20side%20by%20side." target="_blank" rel="noopener" class="share-btn share-x" aria-label="Share on X">𝕏</a>
-    <a href="https://bsky.app/intent/compose?text=java.evolved%20%E2%80%93%20Every%20old%20Java%20pattern%20next%20to%20its%20modern%20replacement%2C%20side%20by%20side.%20https%3A%2F%2Fjavaevolved.github.io" target="_blank" rel="noopener" class="share-btn share-bsky" aria-label="Share on Bluesky">🦋</a>
-    <a href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fjavaevolved.github.io" target="_blank" rel="noopener" class="share-btn share-li" aria-label="Share on LinkedIn">in</a>
-    <a href="https://www.reddit.com/submit?url=https%3A%2F%2Fjavaevolved.github.io&title=java.evolved%20%E2%80%93%20Old%20Java%20vs%20Modern%20Java%2C%20side%20by%20side" target="_blank" rel="noopener" class="share-btn share-reddit" aria-label="Share on Reddit">⬡</a>
+    <a href="https://bsky.app/intent/compose?text=java.evolved%20%E2%80%93%20Every%20old%20Java%20pattern%20next%20to%20its%20modern%20replacement%2C%20side%20by%20side.%20https%3A%2F%2Fjavaevolved.github.io" target="_blank" rel="noopener" class="share-btn share-bsky" aria-label="Share on Bluesky">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M5.202 2.857C7.954 4.922 10.913 9.11 12 11.358c1.087-2.247 4.046-6.436 6.798-8.501C20.783 1.366 24 .213 24 3.883c0 .732-.42 6.156-.667 7.037-.856 3.061-3.978 3.842-6.755 3.37 4.854.826 6.089 3.562 3.422 6.299-5.065 5.196-7.28-1.304-7.847-2.97-.104-.305-.152-.448-.153-.327 0-.121-.05.022-.153.327-.568 1.666-2.782 8.166-7.847 2.97-2.667-2.737-1.432-5.473 3.422-6.3-2.777.473-5.899-.308-6.755-3.369C.42 10.04 0 4.615 0 3.883c0-3.67 3.217-2.517 5.202-1.026"/>
+      </svg>
+    </a>
+    <a href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fjavaevolved.github.io" target="_blank" rel="noopener" class="share-btn share-li" aria-label="Share on LinkedIn">
+      <svg viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854zm4.943 12.248V6.169H2.542v7.225zM3.743 5.182c.837 0 1.358-.554 1.358-1.248-.015-.709-.521-1.248-1.342-1.248S2.4 3.225 2.4 3.934c0 .694.521 1.248 1.327 1.248zm3.105 8.212h2.401V9.359c0-.216.016-.432.079-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.251c0-2.219-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016l.016-.025V6.169H6.848c.03.678 0 7.225 0 7.225"/>
+      </svg>
+    </a>
+    <a href="https://www.reddit.com/submit?url=https%3A%2F%2Fjavaevolved.github.io&title=java.evolved%20%E2%80%93%20Old%20Java%20vs%20Modern%20Java%2C%20side%20by%20side" target="_blank" rel="noopener" class="share-btn share-reddit" aria-label="Share on Reddit">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M12 0C5.373 0 0 5.373 0 12c0 3.314 1.343 6.314 3.515 8.485l-2.286 2.286C.775 23.225 1.097 24 1.738 24H12c6.627 0 12-5.373 12-12S18.627 0 12 0Zm4.388 3.199c1.104 0 1.999.895 1.999 1.999 0 1.105-.895 2-1.999 2-.946 0-1.739-.657-1.947-1.539v.002c-1.147.162-2.032 1.15-2.032 2.341v.007c1.776.067 3.4.567 4.686 1.363.473-.363 1.064-.58 1.707-.58 1.547 0 2.802 1.254 2.802 2.802 0 1.117-.655 2.081-1.601 2.531-.088 3.256-3.637 5.876-7.997 5.876-4.361 0-7.905-2.617-7.998-5.87-.954-.447-1.614-1.415-1.614-2.538 0-1.548 1.255-2.802 2.803-2.802.645 0 1.239.218 1.712.585 1.275-.79 2.881-1.291 4.64-1.365v-.01c0-1.663 1.263-3.034 2.88-3.207.188-.911.993-1.595 1.959-1.595Zm-8.085 8.376c-.784 0-1.459.78-1.506 1.797-.047 1.016.64 1.429 1.426 1.429.786 0 1.371-.369 1.418-1.385.047-1.017-.553-1.841-1.338-1.841Zm7.406 0c-.786 0-1.385.824-1.338 1.841.047 1.017.634 1.385 1.418 1.385.785 0 1.473-.413 1.426-1.429-.046-1.017-.721-1.797-1.506-1.797Zm-3.703 4.013c-.974 0-1.907.048-2.77.135-.147.015-.241.168-.183.305.483 1.154 1.622 1.964 2.953 1.964 1.33 0 2.47-.81 2.953-1.964.057-.137-.037-.29-.184-.305-.863-.087-1.795-.135-2.769-.135Z"/>
+      </svg>
+    </a>
   </div>
 
   <section class="copilot-callout">
     <div class="copilot-callout-inner">
-      <span class="copilot-icon">🤖</span>
+      <svg class="copilot-icon" viewBox="0 0 48 48" aria-hidden="true">
+        <path d="M47.801 34.003c-1.72 2.988-11.706 10.037-23.82 10.037S1.881 36.991.161 34.003a1.309 1.309 0 0 1-.161-.57v-5.615c.012-.17.047-.338.11-.498.744-1.867 2.692-4.58 5.206-5.308.333-.855.826-2.106 1.287-3.029a20.112 20.112 0 0 1-.104-2.171c0-2.659.563-4.992 2.262-6.729.793-.811 1.777-1.433 2.945-1.901C14.502 5.911 18.483 4 23.938 4c5.455 0 9.523 1.911 12.319 4.182 1.167.468 2.151 1.09 2.944 1.901 1.699 1.737 2.263 4.07 2.263 6.729 0 .736-.027 1.465-.105 2.171.461.923.954 2.174 1.288 3.029 2.513.728 4.461 3.441 5.205 5.308.081.205.115.424.115.645v5.318c0 .252-.04.502-.166.72ZM24.325 22.031h-.688a8.52 8.52 0 0 1-.709 1.016c-1.537 1.892-3.833 2.98-7.008 2.98-3.447 0-5.972-.717-7.557-2.514a4.408 4.408 0 0 1-.171-.21l-.195.21v13.155c2.867 1.558 9.02 4.353 15.984 4.353s13.117-2.795 15.984-4.353V23.513l-.195-.21s-.066.091-.171.21c-1.584 1.797-4.11 2.514-7.557 2.514-3.175 0-5.47-1.088-7.008-2.98a8.637 8.637 0 0 1-.709-1.016h-.033.033Zm-1.969-5.864a14.31 14.31 0 0 0 .127-1.785v-.042c-.003-1.537-.339-2.538-.876-3.152-.681-.78-2.09-1.378-5.06-1.057-3.008.326-4.69 1.073-5.643 2.048-.923.944-1.408 2.356-1.408 4.633 0 2.42.348 3.849 1.115 4.719.729.827 2.165 1.499 5.309 1.499 2.417 0 3.799-.786 4.683-1.873.948-1.168 1.482-2.878 1.753-4.99Zm3.25 0c.271 2.112.805 3.822 1.754 4.99.883 1.087 2.265 1.873 4.682 1.873 3.145 0 4.58-.672 5.309-1.499.767-.87 1.116-2.299 1.116-4.719 0-2.277-.485-3.689-1.408-4.633-.954-.975-2.635-1.722-5.644-2.048-2.969-.321-4.378.277-5.06 1.057-.537.614-.873 1.615-.876 3.152v.042c.002.53.042 1.123.127 1.785Z"/>
+        <path d="M28.998 28.516c1.104 0 1.999.895 1.999 1.999v3.998a2 2 0 1 1-3.998 0v-3.998c0-1.104.895-1.999 1.999-1.999Zm-9.996 0c1.104 0 1.999.895 1.999 1.999v3.998a2 2 0 1 1-3.998 0v-3.998c0-1.104.895-1.999 1.999-1.999Z"/>
+      </svg>
       <div class="copilot-callout-text">
         <strong>{{copilot.headline}}</strong>
         {{copilot.description}}
       </div>
       <div class="copilot-callout-links">
-        <a href="https://github.com/solutions/use-case/app-modernization" target="_blank" rel="noopener">{{copilot.appModernization}}</a>
-        <a href="https://docs.github.com/en/enterprise-cloud@latest/copilot/tutorials/modernize-java-applications" target="_blank" rel="noopener">{{copilot.javaGuide}}</a>
+        <a href="https://learn.microsoft.com/en-us/azure/developer/github-copilot-app-modernization/" target="_blank" rel="noopener">{{copilot.appModernization}}</a>
       </div>
     </div>
   </section>
@@ -249,7 +262,6 @@
   <section class="section" id="all-comparisons" style="padding-top:24px">
     <div class="section-header">
       <h2 class="section-title">{{site.allComparisons}}</h2>
-      <span class="section-badge">{{site.snippetsBadge}}</span>
     </div>
     <div class="view-toggle-wrap">
       <div class="jdk-dropdown" id="categoryDropdown">
@@ -283,6 +295,10 @@
           <li data-jdk-filter="25">Java 25</li>
         </ul>
       </div>
+      <button class="show-all-btn" id="showAllButton" type="button"
+              data-show-label="{{filters.showAll}}" data-hide-label="{{filters.hideAll}}">
+        {{filters.showAll}}
+      </button>
       <button class="view-toggle-btn" id="viewToggle" aria-label="Toggle view mode">
         <span class="view-toggle-icon">⊞</span>
         <span class="view-toggle-text">{{view.expandAll}}</span>
@@ -290,6 +306,10 @@
     </div>
     <div class="tips-grid" id="tipsGrid">
 {{tipCards}}
+    </div>
+    <div class="pattern-start-message" id="patternStartMessage">
+      <span class="pattern-start-icon" aria-hidden="true">⌕</span>
+      <p>{{filters.browsePrompt}}</p>
     </div>
     <p class="no-results-message" id="noResultsMessage" style="display:none">{{filters.noResults}}</p>
   </section>

--- a/templates/social-share.html
+++ b/templates/social-share.html
@@ -1,7 +1,19 @@
   <div class="social-share">
     <span class="share-label">{{share.label}}</span>
     <a href="https://x.com/intent/tweet?url={{encodedUrl}}&text={{encodedText}}" target="_blank" rel="noopener" class="share-btn share-x" aria-label="Share on X">𝕏</a>
-    <a href="https://bsky.app/intent/compose?text={{encodedText}}%20{{encodedUrl}}" target="_blank" rel="noopener" class="share-btn share-bsky" aria-label="Share on Bluesky">🦋</a>
-    <a href="https://www.linkedin.com/sharing/share-offsite/?url={{encodedUrl}}" target="_blank" rel="noopener" class="share-btn share-li" aria-label="Share on LinkedIn">in</a>
-    <a href="https://www.reddit.com/submit?url={{encodedUrl}}&title={{encodedText}}" target="_blank" rel="noopener" class="share-btn share-reddit" aria-label="Share on Reddit">⬡</a>
+    <a href="https://bsky.app/intent/compose?text={{encodedText}}%20{{encodedUrl}}" target="_blank" rel="noopener" class="share-btn share-bsky" aria-label="Share on Bluesky">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M5.202 2.857C7.954 4.922 10.913 9.11 12 11.358c1.087-2.247 4.046-6.436 6.798-8.501C20.783 1.366 24 .213 24 3.883c0 .732-.42 6.156-.667 7.037-.856 3.061-3.978 3.842-6.755 3.37 4.854.826 6.089 3.562 3.422 6.299-5.065 5.196-7.28-1.304-7.847-2.97-.104-.305-.152-.448-.153-.327 0-.121-.05.022-.153.327-.568 1.666-2.782 8.166-7.847 2.97-2.667-2.737-1.432-5.473 3.422-6.3-2.777.473-5.899-.308-6.755-3.369C.42 10.04 0 4.615 0 3.883c0-3.67 3.217-2.517 5.202-1.026"/>
+      </svg>
+    </a>
+    <a href="https://www.linkedin.com/sharing/share-offsite/?url={{encodedUrl}}" target="_blank" rel="noopener" class="share-btn share-li" aria-label="Share on LinkedIn">
+      <svg viewBox="0 0 16 16" aria-hidden="true">
+        <path d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854zm4.943 12.248V6.169H2.542v7.225zM3.743 5.182c.837 0 1.358-.554 1.358-1.248-.015-.709-.521-1.248-1.342-1.248S2.4 3.225 2.4 3.934c0 .694.521 1.248 1.327 1.248zm3.105 8.212h2.401V9.359c0-.216.016-.432.079-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.251c0-2.219-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016l.016-.025V6.169H6.848c.03.678 0 7.225 0 7.225"/>
+      </svg>
+    </a>
+    <a href="https://www.reddit.com/submit?url={{encodedUrl}}&title={{encodedText}}" target="_blank" rel="noopener" class="share-btn share-reddit" aria-label="Share on Reddit">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M12 0C5.373 0 0 5.373 0 12c0 3.314 1.343 6.314 3.515 8.485l-2.286 2.286C.775 23.225 1.097 24 1.738 24H12c6.627 0 12-5.373 12-12S18.627 0 12 0Zm4.388 3.199c1.104 0 1.999.895 1.999 1.999 0 1.105-.895 2-1.999 2-.946 0-1.739-.657-1.947-1.539v.002c-1.147.162-2.032 1.15-2.032 2.341v.007c1.776.067 3.4.567 4.686 1.363.473-.363 1.064-.58 1.707-.58 1.547 0 2.802 1.254 2.802 2.802 0 1.117-.655 2.081-1.601 2.531-.088 3.256-3.637 5.876-7.997 5.876-4.361 0-7.905-2.617-7.998-5.87-.954-.447-1.614-1.415-1.614-2.538 0-1.548 1.255-2.802 2.803-2.802.645 0 1.239.218 1.712.585 1.275-.79 2.881-1.291 4.64-1.365v-.01c0-1.663 1.263-3.034 2.88-3.207.188-.911.993-1.595 1.959-1.595Zm-8.085 8.376c-.784 0-1.459.78-1.506 1.797-.047 1.016.64 1.429 1.426 1.429.786 0 1.371-.369 1.418-1.385.047-1.017-.553-1.841-1.338-1.841Zm7.406 0c-.786 0-1.385.824-1.338 1.841.047 1.017.634 1.385 1.418 1.385.785 0 1.473-.413 1.426-1.429-.046-1.017-.721-1.797-1.506-1.797Zm-3.703 4.013c-.974 0-1.907.048-2.77.135-.147.015-.241.168-.183.305.483 1.154 1.622 1.964 2.953 1.964 1.33 0 2.47-.81 2.953-1.964.057-.137-.037-.29-.184-.305-.863-.087-1.795-.135-2.769-.135Z"/>
+      </svg>
+    </a>
   </div>

--- a/translations/strings/ar.yaml
+++ b/translations/strings/ar.yaml
@@ -2,8 +2,7 @@ site:
   tagline: "تطوّرت Java. يمكن لكودك ذلك أيضاً."
   tagline_line1: "تطوّرت Java."
   tagline_line2: "يمكن لكودك ذلك أيضاً."
-  description: "مجموعة من مقاطع كود Java الحديثة. كل نمط قديم بجانب بديله الحديث والنظيف — جنباً إلى جنب."
-  heroSnippetCount: "✦ {{snippetCount}} نمطاً حديثاً · Java 8 ← Java 25"
+  description: "مجموعة تضم {{snippetCount}} من مقاطع كود Java الحديثة. كل نمط قديم بجانب بديله الحديث والنظيف — جنباً إلى جنب."
   heroOld: قديم
   heroModern: حديث
   allComparisons: جميع المقارنات
@@ -31,6 +30,10 @@ sections:
 filters:
   show: "عرض:"
   all: الكل
+  category: "الفئة:"
+  showAll: عرض الكل
+  hideAll: إخفاء الكل
+  browsePrompt: اختر فئة أو إصدار JDK للعثور على أنماط Java الأكثر صلة بك.
   noResults: لم يتم العثور على أنماط برمجية لهذا الفلتر.
 difficulty:
   beginner: مبتدئ

--- a/translations/strings/bn.yaml
+++ b/translations/strings/bn.yaml
@@ -3,8 +3,7 @@ site:
   tagline: জাভাতে এসেছে নতুন দিগন্ত, আপনার কোডও হোক প্রাণবন্ত
   tagline_line1: জাভাতে এসেছে নতুন দিগন্ত,
   tagline_line2: আপনার কোডও হোক প্রাণবন্ত।
-  description: আধুনিক জাভা কোড সংকলন। প্রতিটি পুরনো প্যাটার্ন ও তার পরিচ্ছন্ন বিকল্পের পাশাপাশি তুলনা।।
-  heroSnippetCount: ✦ {{snippetCount}} আধুনিক প্যাটার্ন · Java 8 → Java 25
+  description: "{{snippetCount}}টি আধুনিক জাভা কোড স্নিপেটের সংকলন। প্রতিটি পুরনো প্যাটার্ন ও তার পরিচ্ছন্ন বিকল্পের পাশাপাশি তুলনা।"
   heroOld: পুরনো
   heroModern: আধুনিক
   allComparisons: সব তুলনা
@@ -34,6 +33,9 @@ filters:
   all: সব
   jdk: 'JDK:'
   category: 'বিভাগ:'
+  showAll: সব দেখান
+  hideAll: সব লুকান
+  browsePrompt: সবচেয়ে প্রাসঙ্গিক Java প্যাটার্ন খুঁজতে একটি বিভাগ বা JDK সংস্করণ বেছে নিন।
   noResults: এই ফিল্টারের জন্য কোনো কোড প্যাটার্ন পাওয়া যায়নি।
 difficulty:
   beginner: প্রাথমিক

--- a/translations/strings/de.yaml
+++ b/translations/strings/de.yaml
@@ -3,9 +3,8 @@ site:
   tagline: Java hat sich weiterentwickelt. Dein Code auch.
   tagline_line1: Java hat sich weiterentwickelt.
   tagline_line2: Dein Code auch.
-  description: Eine Sammlung moderner Java-Code-Snippets. Jedes alte Java-Muster neben
+  description: Eine Sammlung von {{snippetCount}} modernen Java-Code-Snippets. Jedes alte Java-Muster neben
     seiner sauberen, modernen Entsprechung — Seite an Seite.
-  heroSnippetCount: ✦ {{snippetCount}} moderne Muster · Java 8 → Java 25
   heroOld: Alt
   heroModern: Modern
   allComparisons: Alle Vergleiche
@@ -33,6 +32,10 @@ sections:
 filters:
   show: 'Anzeigen:'
   all: Alle
+  category: 'Kategorie:'
+  showAll: Alle anzeigen
+  hideAll: Alle ausblenden
+  browsePrompt: Wähle eine Kategorie oder JDK-Version, um die relevantesten Java-Muster zu finden.
   noResults: Keine Code-Muster für diesen Filter gefunden.
 difficulty:
   beginner: Einsteiger

--- a/translations/strings/en.yaml
+++ b/translations/strings/en.yaml
@@ -3,9 +3,8 @@ site:
   tagline: Java has evolved. Your code can too.
   tagline_line1: Java has evolved.
   tagline_line2: Your code can too.
-  description: A collection of modern Java code snippets. Every old Java pattern next
+  description: A collection of {{snippetCount}} modern Java code snippets. Every old Java pattern next
     to its clean, modern replacement — side by side.
-  heroSnippetCount: ✦ {{snippetCount}} modern patterns · Java 8 → Java 25
   heroOld: Old
   heroModern: Modern
   allComparisons: All comparisons
@@ -43,6 +42,9 @@ filters:
   all: All
   jdk: 'JDK:'
   category: 'Category:'
+  showAll: Show all
+  hideAll: Hide all
+  browsePrompt: Choose a category or JDK to find the Java patterns most relevant to you.
   noResults: No code patterns found for this filter.
 difficulty:
   beginner: Beginner

--- a/translations/strings/es.yaml
+++ b/translations/strings/es.yaml
@@ -3,9 +3,8 @@ site:
   tagline: Java ha evolucionado. Tu código también puede.
   tagline_line1: Java ha evolucionado.
   tagline_line2: Tu código también puede.
-  description: Una colección de snippets de Java moderno. Cada patrón antiguo junto
+  description: Una colección de {{snippetCount}} snippets de Java moderno. Cada patrón antiguo junto
     a su reemplazo moderno y limpio — lado a lado.
-  heroSnippetCount: ✦ {{snippetCount}} patrones modernos · Java 8 → Java 25
   heroOld: Antiguo
   heroModern: Moderno
   allComparisons: Todas las comparaciones
@@ -33,6 +32,10 @@ sections:
 filters:
   show: 'Mostrar:'
   all: Todos
+  category: 'Categoría:'
+  showAll: Mostrar todos
+  hideAll: Ocultar todos
+  browsePrompt: Elige una categoría o versión de JDK para encontrar los patrones de Java más relevantes.
   noResults: No se encontraron patrones de código para este filtro.
 difficulty:
   beginner: Principiante

--- a/translations/strings/fr.yaml
+++ b/translations/strings/fr.yaml
@@ -3,9 +3,8 @@ site:
   tagline: Java a évolué. Votre code peut aussi.
   tagline_line1: Java a évolué.
   tagline_line2: Votre code peut aussi.
-  description: Une collection de snippets Java modernes. Chaque ancien pattern Java
+  description: Une collection de {{snippetCount}} snippets Java modernes. Chaque ancien pattern Java
     à côté de son remplacement moderne et propre — côte à côte.
-  heroSnippetCount: ✦ {{snippetCount}} patterns modernes · Java 8 → Java 25
   heroOld: Ancien
   heroModern: Moderne
   allComparisons: Toutes les comparaisons
@@ -33,6 +32,10 @@ sections:
 filters:
   show: 'Afficher :'
   all: Tous
+  category: 'Catégorie :'
+  showAll: Tout afficher
+  hideAll: Tout masquer
+  browsePrompt: Choisissez une catégorie ou une version du JDK pour trouver les patterns Java les plus pertinents.
   noResults: Aucun patron de code trouvé pour ce filtre.
 difficulty:
   beginner: Débutant

--- a/translations/strings/it.yaml
+++ b/translations/strings/it.yaml
@@ -3,9 +3,8 @@ site:
   tagline: Java si è evoluto. Anche il tuo codice può.
   tagline_line1: Java si è evoluto.
   tagline_line2: Anche il tuo codice può.
-  description: Una raccolta di snippet Java moderni. Ogni vecchio pattern Java accanto
+  description: Una raccolta di {{snippetCount}} snippet Java moderni. Ogni vecchio pattern Java accanto
     al suo sostituto moderno e pulito — fianco a fianco.
-  heroSnippetCount: ✦ {{snippetCount}} pattern moderni · Java 8 → Java 25
   heroOld: Vecchio
   heroModern: Moderno
   allComparisons: Tutti i confronti
@@ -33,6 +32,10 @@ sections:
 filters:
   show: 'Mostra:'
   all: Tutti
+  category: 'Categoria:'
+  showAll: Mostra tutti
+  hideAll: Nascondi tutti
+  browsePrompt: Scegli una categoria o una versione JDK per trovare i pattern Java più pertinenti.
   noResults: Nessun pattern di codice trovato per questo filtro.
 difficulty:
   beginner: Principiante

--- a/translations/strings/ja.yaml
+++ b/translations/strings/ja.yaml
@@ -2,8 +2,7 @@ site:
   tagline: Javaは進化した。あなたのコードも。
   tagline_line1: Javaは進化した。
   tagline_line2: あなたのコードも。
-  description: モダンなJavaコードスニペットのコレクション。古いパターンとその洗練されたモダンな置き換えを並べて比較。
-  heroSnippetCount: ✦ {{snippetCount}} のモダンパターン · Java 8 → Java 25
+  description: "{{snippetCount}}個のモダンなJavaコードスニペットのコレクション。古いパターンとその洗練されたモダンな置き換えを並べて比較。"
   heroOld: 旧来
   heroModern: モダン
   allComparisons: すべての比較
@@ -31,6 +30,10 @@ sections:
 filters:
   show: '表示:'
   all: すべて
+  category: 'カテゴリ:'
+  showAll: すべて表示
+  hideAll: すべて非表示
+  browsePrompt: カテゴリまたはJDKバージョンを選択して、関連するJavaパターンを見つけてください。
   noResults: このフィルターに一致するコードパターンが見つかりません。
 difficulty:
   beginner: 初級

--- a/translations/strings/ko.yaml
+++ b/translations/strings/ko.yaml
@@ -2,8 +2,7 @@ site:
   tagline: Java는 진화했습니다. 당신의 코드도 그럴 수 있습니다.
   tagline_line1: Java는 진화했습니다.
   tagline_line2: 당신의 코드도 그럴 수 있습니다.
-  description: 모던 Java 코드 스니펫 모음. 오래된 Java 패턴과 깔끔하고 모던한 대체 코드를 나란히 비교합니다.
-  heroSnippetCount: ✦ {{snippetCount}}개의 모던 패턴 · Java 8 → Java 25
+  description: "{{snippetCount}}개의 모던 Java 코드 스니펫 모음. 오래된 Java 패턴과 깔끔하고 모던한 대체 코드를 나란히 비교합니다."
   heroOld: 이전
   heroModern: 모던
   allComparisons: 모든 비교
@@ -31,6 +30,10 @@ sections:
 filters:
   show: '표시:'
   all: 전체
+  category: '카테고리:'
+  showAll: 모두 표시
+  hideAll: 모두 숨기기
+  browsePrompt: 카테고리 또는 JDK 버전을 선택하여 가장 관련 있는 Java 패턴을 찾아보세요.
   noResults: 이 필터에 해당하는 코드 패턴이 없습니다.
 difficulty:
   beginner: 초급

--- a/translations/strings/pl.yaml
+++ b/translations/strings/pl.yaml
@@ -3,8 +3,7 @@ site:
   tagline: Java ewoluowała. Twój kod też może.
   tagline_line1: Java ewoluowała.
   tagline_line2: Twój kod też może.
-  description: Zbiór nowoczesnych snippetów Java. Każdy stary wzorzec Java obok jego czystego, nowoczesnego odpowiednika.
-  heroSnippetCount: ✦ {{snippetCount}} nowoczesnych wzorców · Java 8 → Java 25
+  description: Zbiór {{snippetCount}} nowoczesnych snippetów Java. Każdy stary wzorzec Java obok jego czystego, nowoczesnego odpowiednika.
   heroOld: Stare
   heroModern: Nowe
   allComparisons: Wszystkie porównania
@@ -32,6 +31,10 @@ sections:
 filters:
   show: 'Pokaż:'
   all: Wszystkie
+  category: 'Kategoria:'
+  showAll: Pokaż wszystkie
+  hideAll: Ukryj wszystkie
+  browsePrompt: Wybierz kategorię lub wersję JDK, aby znaleźć najbardziej odpowiednie wzorce Java.
   noResults: Nie znaleziono wzorców kodu dla tego filtra.
 difficulty:
   beginner: Początkujący

--- a/translations/strings/pt-BR.yaml
+++ b/translations/strings/pt-BR.yaml
@@ -2,9 +2,8 @@ site:
   tagline: O Java evoluiu. Seu código também pode.
   tagline_line1: O Java evoluiu.
   tagline_line2: Seu código também pode.
-  description: Uma coleção de snippets modernos de Java. Cada padrão antigo ao lado
+  description: Uma coleção de {{snippetCount}} snippets modernos de Java. Cada padrão antigo ao lado
     da sua substituição moderna e limpa — lado a lado.
-  heroSnippetCount: ✦ {{snippetCount}} padrões modernos · Java 8 → Java 25
   heroOld: Antigo
   heroModern: Moderno
   allComparisons: Todas as comparações
@@ -32,6 +31,10 @@ sections:
 filters:
   show: 'Mostrar:'
   all: Todos
+  category: 'Categoria:'
+  showAll: Mostrar todos
+  hideAll: Ocultar todos
+  browsePrompt: Escolha uma categoria ou versão do JDK para encontrar os padrões Java mais relevantes.
   noResults: Nenhum padrão de código encontrado para este filtro.
 difficulty:
   beginner: Iniciante

--- a/translations/strings/ru.yaml
+++ b/translations/strings/ru.yaml
@@ -3,9 +3,8 @@ site:
   tagline: Java эволюционировал. Ваш код тоже может.
   tagline_line1: Java эволюционировал.
   tagline_line2: Ваш код тоже может.
-  description: Коллекция современных фрагментов кода на Java. Каждый устаревший шаблон
+  description: Коллекция из {{snippetCount}} современных фрагментов кода на Java. Каждый устаревший шаблон
     рядом с его чистой, современной заменой — бок о бок.
-  heroSnippetCount: ✦ {{snippetCount}} современных шаблонов · Java 8 → Java 25
   heroOld: Старый
   heroModern: Современный
   allComparisons: Все сравнения
@@ -35,6 +34,9 @@ filters:
   all: Все
   jdk: 'JDK:'
   category: 'Категория:'
+  showAll: Показать все
+  hideAll: Скрыть все
+  browsePrompt: Выберите категорию или версию JDK, чтобы найти наиболее подходящие шаблоны Java.
   noResults: Шаблоны кода для этого фильтра не найдены.
 difficulty:
   beginner: Начинающий

--- a/translations/strings/tr.yaml
+++ b/translations/strings/tr.yaml
@@ -3,8 +3,7 @@ site:
   tagline: Java gelişti. Kodun da gelişebilir.
   tagline_line1: Java gelişti.
   tagline_line2: Kodun da gelişebilir.
-  description: Modern Java kod parçacıklarından oluşan bir koleksiyon. Her eski Java deseni, temiz ve modern karşılığının yanında — yan yana.
-  heroSnippetCount: ✦ {{snippetCount}} modern desen · Java 8 → Java 25
+  description: "{{snippetCount}} modern Java kod parçacığından oluşan bir koleksiyon. Her eski Java deseni, temiz ve modern karşılığının yanında — yan yana."
   heroOld: Eski
   heroModern: Modern
   allComparisons: Tüm karşılaştırmalar
@@ -32,6 +31,10 @@ sections:
 filters:
   show: 'Göster:'
   all: Tümü
+  category: 'Kategori:'
+  showAll: Tümünü göster
+  hideAll: Tümünü gizle
+  browsePrompt: En uygun Java desenlerini bulmak için bir kategori veya JDK sürümü seçin.
   noResults: Bu filtre için kod deseni bulunamadı.
 difficulty:
   beginner: Başlangıç

--- a/translations/strings/zh-CN.yaml
+++ b/translations/strings/zh-CN.yaml
@@ -3,8 +3,7 @@ site:
   tagline: Java 已进化。您的代码也可以。
   tagline_line1: Java 已进化。
   tagline_line2: 您的代码也可以。
-  description: 现代 Java 代码片段集合。每个旧 Java 模式与其简洁的现代替代方案并排展示。
-  heroSnippetCount: ✦ {{snippetCount}} 个现代模式 · Java 8 → Java 25
+  description: 由 {{snippetCount}} 个现代 Java 代码片段组成的集合。每个旧 Java 模式与其简洁的现代替代方案并排展示。
   heroOld: 旧版
   heroModern: 现代
   allComparisons: 所有对比
@@ -32,6 +31,10 @@ sections:
 filters:
   show: '显示：'
   all: 全部
+  category: '类别：'
+  showAll: 显示全部
+  hideAll: 隐藏全部
+  browsePrompt: 选择类别或 JDK 版本，查找最相关的 Java 模式。
   noResults: 未找到与此筛选条件匹配的代码模式。
 difficulty:
   beginner: 入门


### PR DESCRIPTION
The homepage currently presents all patterns immediately, which makes the first view visually dense and harder to explore. This change introduces a calmer discovery-first experience while preserving direct access through category hashes and explicit filtering.

## What changed

- Hide pattern cards on first load and prompt visitors to browse by Category or JDK.
- Add a localized Show all / Hide all control that clears active filters and stays synchronized with filter state.
- Localize the Category label across supported locales while keeping category names unchanged.
- Simplify the homepage hierarchy by removing redundant count badges and moving the live pattern count into the description.
- Refine the Copilot modernization callout and replace placeholder social marks with accessible SVG brand icons.
- Improve responsive wrapping and empty/discovery states without changing generated pattern content.

## Validation

- Regenerated all localized pages with `jbang html-generators/generate.java`.
- Reviewed the homepage through the local browser preview in desktop and narrow layouts.