### PR TITLE
Build Java detector JAR in CI

### DIFF
--- a/.github/workflows/build-generator.yml
+++ b/.github/workflows/build-generator.yml
@@ -1,4 +1,4 @@
-name: Build Generator JARs
+name: Build Project JARs
 
 on:
   push:
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/build-generator.yml'
       - 'html-generators/generate.java'
       - 'html-generators/generateog.java'
+      - 'agent-plugins/modern-java-development/skills/modern-java/scripts/DetectJavaVersion.java'
   schedule:
     - cron: '0 6 * * 1'   # every Monday at 06:00 UTC
   workflow_dispatch:
@@ -67,3 +68,54 @@ jobs:
             html-generators/generateog.jar
             html-generators/generateog.aot
           key: generateog-${{ hashFiles('html-generators/generateog.java') }}
+
+  build-detect-java-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: '8'
+
+      - name: Build Java version detector JAR
+        working-directory: agent-plugins/modern-java-development
+        run: |
+          classes=$(mktemp -d)
+          trap 'rm -rf "$classes"' EXIT
+          jarfile="skills/modern-java/scripts/detect-java-version.jar"
+          mkdir "$classes/compiled" "$classes/shipped"
+          javac -source 8 -target 8 -Xlint:-options \
+            -d "$classes/compiled" skills/modern-java/scripts/DetectJavaVersion.java
+          (
+            cd "$classes/shipped"
+            jar xf "$GITHUB_WORKSPACE/agent-plugins/modern-java-development/$jarfile"
+          )
+          rm -rf "$classes/shipped/META-INF"
+          if diff --recursive --quiet "$classes/compiled" "$classes/shipped"; then
+            exit 0
+          fi
+          jar cfe "$jarfile" DetectJavaVersion -C "$classes/compiled" .
+
+      - name: Verify Java version detector JAR
+        working-directory: agent-plugins/modern-java-development
+        run: |
+          jarfile="skills/modern-java/scripts/detect-java-version.jar"
+          java -jar "$jarfile" --help >/dev/null
+          javap -verbose -classpath "$jarfile" DetectJavaVersion \
+            | grep --quiet 'major version: 52'
+
+      - name: Commit Java version detector JAR
+        run: |
+          jarfile="agent-plugins/modern-java-development/skills/modern-java/scripts/detect-java-version.jar"
+          if git diff --quiet -- "$jarfile"; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$jarfile"
+          git commit -m "Rebuild Java version detector JAR"
+          git push origin HEAD:main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ on:
       - 'html-generators/tags.properties'
       - 'html-generators/categories.properties'
   workflow_run:
-    workflows: ['Build Generator JARs']
+    workflows: ['Build Project JARs']
     types: [completed]
     branches: [main]
   workflow_dispatch:


### PR DESCRIPTION
The checked-in Java version detector JAR can drift from its source because the existing JAR workflow only builds the site generators.

Rename the workflow to `Build Project JARs` and add a Temurin Java 8 job that compiles, packages, and verifies the detector. The job compares compiled classes with the shipped JAR before rebuilding, preventing timestamp-only commits, and pushes a bot commit to `main` only when the tracked JAR genuinely changes. The deploy workflow now follows the renamed build workflow.