### PR TITLE
Add spacing below comparison filters

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -735,7 +735,7 @@ nav {
   justify-content: center;
   align-items: center;
   gap: 10px;
-  margin: 0;
+  margin: 0 0 24px;
 }
 
 /* ---------- JDK Dropdown ---------- */


### PR DESCRIPTION
The comparison filter controls sit too close to the cards, making the two groups visually run together. Add 24px of bottom spacing to the filter control row so the controls remain grouped while the card grid has clear separation.