### PR TITLE
Keep show-all button width stable

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -229,7 +229,7 @@
 
     const updateShowAllButton = () => {
       if (!showAllButton) return;
-      showAllButton.textContent = showingAll
+      showAllButton.querySelector('.show-all-btn-text').textContent = showingAll
         ? showAllButton.dataset.hideLabel
         : showAllButton.dataset.showLabel;
     };

--- a/site/styles.css
+++ b/site/styles.css
@@ -497,6 +497,7 @@ nav {
 }
 
 .show-all-btn {
+  display: grid;
   padding: 10px 20px;
   color: var(--text);
   font: inherit;
@@ -507,6 +508,25 @@ nav {
   border-radius: var(--radius-sm);
   cursor: pointer;
   transition: all 0.25s;
+}
+
+.show-all-btn::before,
+.show-all-btn::after,
+.show-all-btn-text {
+  grid-area: 1 / 1;
+}
+
+.show-all-btn::before,
+.show-all-btn::after {
+  visibility: hidden;
+}
+
+.show-all-btn::before {
+  content: attr(data-show-label);
+}
+
+.show-all-btn::after {
+  content: attr(data-hide-label);
 }
 
 .show-all-btn:hover {

--- a/templates/index.html
+++ b/templates/index.html
@@ -300,7 +300,7 @@
       </div>
       <button class="show-all-btn" id="showAllButton" type="button"
               data-show-label="{{filters.showAll}}" data-hide-label="{{filters.hideAll}}">
-        {{filters.showAll}}
+        <span class="show-all-btn-text">{{filters.showAll}}</span>
       </button>
       <button class="view-toggle-btn" id="viewToggle" aria-label="Toggle view mode">
         <span class="view-toggle-icon">⊞</span>


### PR DESCRIPTION
Switching between "Show all" and "Hide all" changed the button width and shifted the filter controls.

Reserve space for both localized labels with overlapping hidden sizing content, while updating only the visible label. This keeps the button width stable across every supported locale.