### PR TITLE
Update social posts to javaevolved.dev

### DIFF
--- a/html-generators/generatesocialqueue.java
+++ b/html-generators/generatesocialqueue.java
@@ -22,7 +22,7 @@ static final String SOCIAL_DIR = "social";
 static final String QUEUE_FILE = SOCIAL_DIR + "/queue.txt";
 static final String TWEETS_DIR = SOCIAL_DIR + "/tweets";
 static final String STATE_FILE = SOCIAL_DIR + "/state.yaml";
-static final String BASE_URL = "https://javaevolved.github.io";
+static final String BASE_URL = "https://javaevolved.dev";
 static final int MAX_TWEET_LENGTH = 280;
 
 static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());

--- a/social/tweets/collections/collection-bulk-operations.yaml
+++ b/social/tweets/collections/collection-bulk-operations.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual iterator removal → Collection.removeIf() (JDK 8+)
   
-  🔗 https://javaevolved.github.io/collections/collection-bulk-operations.html
+  🔗 https://javaevolved.dev/collections/collection-bulk-operations.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/collectors-teeing.yaml
+++ b/social/tweets/collections/collectors-teeing.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Two Passes → teeing() (JDK 12+)
   
-  🔗 https://javaevolved.github.io/collections/collectors-teeing.html
+  🔗 https://javaevolved.dev/collections/collectors-teeing.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/comparator-factories.yaml
+++ b/social/tweets/collections/comparator-factories.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Anonymous Comparator → Comparator factories (JDK 8+)
   
-  🔗 https://javaevolved.github.io/collections/comparator-factories.html
+  🔗 https://javaevolved.dev/collections/comparator-factories.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/copying-collections-immutably.yaml
+++ b/social/tweets/collections/copying-collections-immutably.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Copy + Wrap → List.copyOf() (JDK 10+)
   
-  🔗 https://javaevolved.github.io/collections/copying-collections-immutably.html
+  🔗 https://javaevolved.dev/collections/copying-collections-immutably.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/immutable-list-creation.yaml
+++ b/social/tweets/collections/immutable-list-creation.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Verbose Wrapping → List.of() (JDK 9+)
   
-  🔗 https://javaevolved.github.io/collections/immutable-list-creation.html
+  🔗 https://javaevolved.dev/collections/immutable-list-creation.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/immutable-map-creation.yaml
+++ b/social/tweets/collections/immutable-map-creation.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Map Builder Pattern → Map.of() (JDK 9+)
   
-  🔗 https://javaevolved.github.io/collections/immutable-map-creation.html
+  🔗 https://javaevolved.dev/collections/immutable-map-creation.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/immutable-set-creation.yaml
+++ b/social/tweets/collections/immutable-set-creation.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Verbose Wrapping → Set.of() (JDK 9+)
   
-  🔗 https://javaevolved.github.io/collections/immutable-set-creation.html
+  🔗 https://javaevolved.dev/collections/immutable-set-creation.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/legacy-synchronized-collections.yaml
+++ b/social/tweets/collections/legacy-synchronized-collections.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Hashtable → ConcurrentHashMap (JDK 5+)
   
-  🔗 https://javaevolved.github.io/collections/legacy-synchronized-collections.html
+  🔗 https://javaevolved.dev/collections/legacy-synchronized-collections.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/map-compute-and-merge.yaml
+++ b/social/tweets/collections/map-compute-and-merge.yaml
@@ -5,6 +5,6 @@ text: |-
   
   get() + null check + put() → computeIfAbsent() (JDK 8+)
   
-  🔗 https://javaevolved.github.io/collections/map-compute-and-merge.html
+  🔗 https://javaevolved.dev/collections/map-compute-and-merge.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/map-entry-factory.yaml
+++ b/social/tweets/collections/map-entry-factory.yaml
@@ -5,6 +5,6 @@ text: |-
 
   SimpleEntry → Map.entry() (JDK 9+)
 
-  🔗 https://javaevolved.github.io/collections/map-entry-factory.html
+  🔗 https://javaevolved.dev/collections/map-entry-factory.html
 
   #Java #JavaEvolved

--- a/social/tweets/collections/reverse-list-iteration.yaml
+++ b/social/tweets/collections/reverse-list-iteration.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual ListIterator → reversed() (JDK 21+)
   
-  🔗 https://javaevolved.github.io/collections/reverse-list-iteration.html
+  🔗 https://javaevolved.dev/collections/reverse-list-iteration.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/sequenced-collections.yaml
+++ b/social/tweets/collections/sequenced-collections.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Index Arithmetic → getFirst/getLast (JDK 21+)
   
-  🔗 https://javaevolved.github.io/collections/sequenced-collections.html
+  🔗 https://javaevolved.dev/collections/sequenced-collections.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/stack-to-deque.yaml
+++ b/social/tweets/collections/stack-to-deque.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Stack → Deque with ArrayDeque (JDK 6+)
   
-  🔗 https://javaevolved.github.io/collections/stack-to-deque.html
+  🔗 https://javaevolved.dev/collections/stack-to-deque.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/stream-toarray-typed.yaml
+++ b/social/tweets/collections/stream-toarray-typed.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Filter + Copy → toArray(generator) (JDK 8+)
   
-  🔗 https://javaevolved.github.io/collections/stream-toarray-typed.html
+  🔗 https://javaevolved.dev/collections/stream-toarray-typed.html
   
   #Java #JavaEvolved

--- a/social/tweets/collections/unmodifiable-collectors.yaml
+++ b/social/tweets/collections/unmodifiable-collectors.yaml
@@ -5,6 +5,6 @@ text: |-
   
   collectingAndThen → stream.toList() (JDK 16+)
   
-  🔗 https://javaevolved.github.io/collections/unmodifiable-collectors.html
+  🔗 https://javaevolved.dev/collections/unmodifiable-collectors.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/completablefuture-chaining.yaml
+++ b/social/tweets/concurrency/completablefuture-chaining.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Blocking Future.get() → CompletableFuture (JDK 8+)
   
-  🔗 https://javaevolved.github.io/concurrency/completablefuture-chaining.html
+  🔗 https://javaevolved.dev/concurrency/completablefuture-chaining.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/concurrent-http-virtual.yaml
+++ b/social/tweets/concurrency/concurrent-http-virtual.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Thread Pool + URLConnection → Virtual Threads + HttpClient (JDK 21+)
   
-  🔗 https://javaevolved.github.io/concurrency/concurrent-http-virtual.html
+  🔗 https://javaevolved.dev/concurrency/concurrent-http-virtual.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/executor-try-with-resources.yaml
+++ b/social/tweets/concurrency/executor-try-with-resources.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Shutdown → try-with-resources (JDK 19+)
   
-  🔗 https://javaevolved.github.io/concurrency/executor-try-with-resources.html
+  🔗 https://javaevolved.dev/concurrency/executor-try-with-resources.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/lock-free-lazy-init.yaml
+++ b/social/tweets/concurrency/lock-free-lazy-init.yaml
@@ -5,6 +5,6 @@ text: |-
   
   synchronized + volatile → StableValue (JDK 25+)
   
-  🔗 https://javaevolved.github.io/concurrency/lock-free-lazy-init.html
+  🔗 https://javaevolved.dev/concurrency/lock-free-lazy-init.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/process-api.yaml
+++ b/social/tweets/concurrency/process-api.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Runtime.exec() → ProcessHandle (JDK 9+)
   
-  🔗 https://javaevolved.github.io/concurrency/process-api.html
+  🔗 https://javaevolved.dev/concurrency/process-api.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/scoped-values.yaml
+++ b/social/tweets/concurrency/scoped-values.yaml
@@ -5,6 +5,6 @@ text: |-
   
   ThreadLocal → ScopedValue (JDK 25+)
   
-  🔗 https://javaevolved.github.io/concurrency/scoped-values.html
+  🔗 https://javaevolved.dev/concurrency/scoped-values.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/stable-values.yaml
+++ b/social/tweets/concurrency/stable-values.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Double-Checked Locking → StableValue (JDK 25+)
   
-  🔗 https://javaevolved.github.io/concurrency/stable-values.html
+  🔗 https://javaevolved.dev/concurrency/stable-values.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/structured-concurrency.yaml
+++ b/social/tweets/concurrency/structured-concurrency.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Thread Lifecycle → StructuredTaskScope (JDK 25+)
   
-  🔗 https://javaevolved.github.io/concurrency/structured-concurrency.html
+  🔗 https://javaevolved.dev/concurrency/structured-concurrency.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/thread-sleep-duration.yaml
+++ b/social/tweets/concurrency/thread-sleep-duration.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Milliseconds → Duration (JDK 19+)
   
-  🔗 https://javaevolved.github.io/concurrency/thread-sleep-duration.html
+  🔗 https://javaevolved.dev/concurrency/thread-sleep-duration.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/thread-stop-to-cooperative-cancellation.yaml
+++ b/social/tweets/concurrency/thread-stop-to-cooperative-cancellation.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Thread.stop() → Future.cancel(true) (JDK 5+)
   
-  🔗 https://javaevolved.github.io/concurrency/thread-stop-to-cooperative-cancellation.html
+  🔗 https://javaevolved.dev/concurrency/thread-stop-to-cooperative-cancellation.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/timer-task-to-scheduled-executor.yaml
+++ b/social/tweets/concurrency/timer-task-to-scheduled-executor.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Timer and TimerTask → ScheduledExecutorService (JDK 5+)
   
-  🔗 https://javaevolved.github.io/concurrency/timer-task-to-scheduled-executor.html
+  🔗 https://javaevolved.dev/concurrency/timer-task-to-scheduled-executor.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/virtual-threads.yaml
+++ b/social/tweets/concurrency/virtual-threads.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Platform Threads → Virtual Threads (JDK 21+)
   
-  🔗 https://javaevolved.github.io/concurrency/virtual-threads.html
+  🔗 https://javaevolved.dev/concurrency/virtual-threads.html
   
   #Java #JavaEvolved

--- a/social/tweets/concurrency/wait-notify-to-blocking-queue.yaml
+++ b/social/tweets/concurrency/wait-notify-to-blocking-queue.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual wait and notify → BlockingQueue (JDK 5+)
   
-  🔗 https://javaevolved.github.io/concurrency/wait-notify-to-blocking-queue.html
+  🔗 https://javaevolved.dev/concurrency/wait-notify-to-blocking-queue.html
   
   #Java #JavaEvolved

--- a/social/tweets/datetime/date-formatting.yaml
+++ b/social/tweets/datetime/date-formatting.yaml
@@ -5,6 +5,6 @@ text: |-
   
   SimpleDateFormat → DateTimeFormatter (JDK 8+)
   
-  🔗 https://javaevolved.github.io/datetime/date-formatting.html
+  🔗 https://javaevolved.dev/datetime/date-formatting.html
   
   #Java #JavaEvolved

--- a/social/tweets/datetime/duration-and-period.yaml
+++ b/social/tweets/datetime/duration-and-period.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Millisecond Math → Duration / Period (JDK 8+)
   
-  🔗 https://javaevolved.github.io/datetime/duration-and-period.html
+  🔗 https://javaevolved.dev/datetime/duration-and-period.html
   
   #Java #JavaEvolved

--- a/social/tweets/datetime/hex-format.yaml
+++ b/social/tweets/datetime/hex-format.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Hex Conversion → HexFormat (JDK 17+)
   
-  🔗 https://javaevolved.github.io/datetime/hex-format.html
+  🔗 https://javaevolved.dev/datetime/hex-format.html
   
   #Java #JavaEvolved

--- a/social/tweets/datetime/instant-precision.yaml
+++ b/social/tweets/datetime/instant-precision.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Milliseconds → Nanoseconds (JDK 9+)
   
-  🔗 https://javaevolved.github.io/datetime/instant-precision.html
+  🔗 https://javaevolved.dev/datetime/instant-precision.html
   
   #Java #JavaEvolved

--- a/social/tweets/datetime/java-time-basics.yaml
+++ b/social/tweets/datetime/java-time-basics.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Date + Calendar → java.time.* (JDK 8+)
   
-  🔗 https://javaevolved.github.io/datetime/java-time-basics.html
+  🔗 https://javaevolved.dev/datetime/java-time-basics.html
   
   #Java #JavaEvolved

--- a/social/tweets/datetime/locale-of.yaml
+++ b/social/tweets/datetime/locale-of.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Locale constructors → Locale.of() (JDK 19+)
   
-  🔗 https://javaevolved.github.io/datetime/locale-of.html
+  🔗 https://javaevolved.dev/datetime/locale-of.html
   
   #Java #JavaEvolved

--- a/social/tweets/datetime/math-clamp.yaml
+++ b/social/tweets/datetime/math-clamp.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Nested min/max → Math.clamp() (JDK 21+)
   
-  🔗 https://javaevolved.github.io/datetime/math-clamp.html
+  🔗 https://javaevolved.dev/datetime/math-clamp.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/ejb-timer-vs-jakarta-scheduler.yaml
+++ b/social/tweets/enterprise/ejb-timer-vs-jakarta-scheduler.yaml
@@ -5,6 +5,6 @@ text: |-
   
   EJB TimerService → ManagedScheduledExecutorService (JDK 11+)
   
-  🔗 https://javaevolved.github.io/enterprise/ejb-timer-vs-jakarta-scheduler.html
+  🔗 https://javaevolved.dev/enterprise/ejb-timer-vs-jakarta-scheduler.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/ejb-vs-cdi.yaml
+++ b/social/tweets/enterprise/ejb-vs-cdi.yaml
@@ -5,6 +5,6 @@ text: |-
   
   EJB → CDI Bean (JDK 11+)
   
-  🔗 https://javaevolved.github.io/enterprise/ejb-vs-cdi.html
+  🔗 https://javaevolved.dev/enterprise/ejb-vs-cdi.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/jdbc-resultset-vs-jpa-criteria.yaml
+++ b/social/tweets/enterprise/jdbc-resultset-vs-jpa-criteria.yaml
@@ -5,6 +5,6 @@ text: |-
   
   JDBC ResultSet → JPA Criteria API (JDK 11+)
   
-  🔗 https://javaevolved.github.io/enterprise/jdbc-resultset-vs-jpa-criteria.html
+  🔗 https://javaevolved.dev/enterprise/jdbc-resultset-vs-jpa-criteria.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/jdbc-vs-jooq.yaml
+++ b/social/tweets/enterprise/jdbc-vs-jooq.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Raw JDBC → jOOQ SQL DSL (JDK 11+)
   
-  🔗 https://javaevolved.github.io/enterprise/jdbc-vs-jooq.html
+  🔗 https://javaevolved.dev/enterprise/jdbc-vs-jooq.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/jdbc-vs-jpa.yaml
+++ b/social/tweets/enterprise/jdbc-vs-jpa.yaml
@@ -5,6 +5,6 @@ text: |-
   
   JDBC → JPA EntityManager (JDK 11+)
   
-  🔗 https://javaevolved.github.io/enterprise/jdbc-vs-jpa.html
+  🔗 https://javaevolved.dev/enterprise/jdbc-vs-jpa.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/jndi-lookup-vs-cdi-injection.yaml
+++ b/social/tweets/enterprise/jndi-lookup-vs-cdi-injection.yaml
@@ -5,6 +5,6 @@ text: |-
   
   JNDI Lookup → CDI @Inject (JDK 11+)
   
-  🔗 https://javaevolved.github.io/enterprise/jndi-lookup-vs-cdi-injection.html
+  🔗 https://javaevolved.dev/enterprise/jndi-lookup-vs-cdi-injection.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/jpa-vs-jakarta-data.yaml
+++ b/social/tweets/enterprise/jpa-vs-jakarta-data.yaml
@@ -5,6 +5,6 @@ text: |-
   
   JPA EntityManager → Jakarta Data Repository (JDK 21+)
   
-  🔗 https://javaevolved.github.io/enterprise/jpa-vs-jakarta-data.html
+  🔗 https://javaevolved.dev/enterprise/jpa-vs-jakarta-data.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/jsf-managed-bean-vs-cdi-named.yaml
+++ b/social/tweets/enterprise/jsf-managed-bean-vs-cdi-named.yaml
@@ -5,6 +5,6 @@ text: |-
   
   @ManagedBean → @Named + CDI (JDK 11+)
   
-  🔗 https://javaevolved.github.io/enterprise/jsf-managed-bean-vs-cdi-named.html
+  🔗 https://javaevolved.dev/enterprise/jsf-managed-bean-vs-cdi-named.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/manual-transaction-vs-declarative.yaml
+++ b/social/tweets/enterprise/manual-transaction-vs-declarative.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Transaction → @Transactional (JDK 11+)
   
-  🔗 https://javaevolved.github.io/enterprise/manual-transaction-vs-declarative.html
+  🔗 https://javaevolved.dev/enterprise/manual-transaction-vs-declarative.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/mdb-vs-reactive-messaging.yaml
+++ b/social/tweets/enterprise/mdb-vs-reactive-messaging.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Message-Driven Bean → Reactive Messaging (JDK 11+)
   
-  🔗 https://javaevolved.github.io/enterprise/mdb-vs-reactive-messaging.html
+  🔗 https://javaevolved.dev/enterprise/mdb-vs-reactive-messaging.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/servlet-vs-jaxrs.yaml
+++ b/social/tweets/enterprise/servlet-vs-jaxrs.yaml
@@ -5,6 +5,6 @@ text: |-
   
   HttpServlet → JAX-RS Resource (JDK 11+)
   
-  🔗 https://javaevolved.github.io/enterprise/servlet-vs-jaxrs.html
+  🔗 https://javaevolved.dev/enterprise/servlet-vs-jaxrs.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/singleton-ejb-vs-cdi-application-scoped.yaml
+++ b/social/tweets/enterprise/singleton-ejb-vs-cdi-application-scoped.yaml
@@ -5,6 +5,6 @@ text: |-
   
   @Singleton EJB → @ApplicationScoped CDI (JDK 11+)
   
-  🔗 https://javaevolved.github.io/enterprise/singleton-ejb-vs-cdi-application-scoped.html
+  🔗 https://javaevolved.dev/enterprise/singleton-ejb-vs-cdi-application-scoped.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/soap-vs-jakarta-rest.yaml
+++ b/social/tweets/enterprise/soap-vs-jakarta-rest.yaml
@@ -5,6 +5,6 @@ text: |-
   
   JAX-WS / SOAP → Jakarta REST / JSON (JDK 11+)
   
-  🔗 https://javaevolved.github.io/enterprise/soap-vs-jakarta-rest.html
+  🔗 https://javaevolved.dev/enterprise/soap-vs-jakarta-rest.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/spring-api-versioning.yaml
+++ b/social/tweets/enterprise/spring-api-versioning.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual URL Path Versioning → Native API Versioning (JDK 17+)
   
-  🔗 https://javaevolved.github.io/enterprise/spring-api-versioning.html
+  🔗 https://javaevolved.dev/enterprise/spring-api-versioning.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/spring-boot-mvc-config.yaml
+++ b/social/tweets/enterprise/spring-boot-mvc-config.yaml
@@ -5,6 +5,6 @@ text: |-
   
   WebMvcConfigurerAdapter with @EnableWebMvc → WebMvcConfigurer with Spring Boot Auto-Configuration (JDK 17+)
   
-  🔗 https://javaevolved.github.io/enterprise/spring-boot-mvc-config.html
+  🔗 https://javaevolved.dev/enterprise/spring-boot-mvc-config.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/spring-null-safety-jspecify.yaml
+++ b/social/tweets/enterprise/spring-null-safety-jspecify.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Spring @NonNull/@Nullable → JSpecify @NullMarked (JDK 17+)
   
-  🔗 https://javaevolved.github.io/enterprise/spring-null-safety-jspecify.html
+  🔗 https://javaevolved.dev/enterprise/spring-null-safety-jspecify.html
   
   #Java #JavaEvolved

--- a/social/tweets/enterprise/spring-xml-config-vs-annotations.yaml
+++ b/social/tweets/enterprise/spring-xml-config-vs-annotations.yaml
@@ -5,6 +5,6 @@ text: |-
   
   XML Bean Definitions → Annotation-Driven Beans (JDK 17+)
   
-  🔗 https://javaevolved.github.io/enterprise/spring-xml-config-vs-annotations.html
+  🔗 https://javaevolved.dev/enterprise/spring-xml-config-vs-annotations.html
   
   #Java #JavaEvolved

--- a/social/tweets/errors/helpful-npe.yaml
+++ b/social/tweets/errors/helpful-npe.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Cryptic NPE → Detailed NPE (JDK 14+)
   
-  🔗 https://javaevolved.github.io/errors/helpful-npe.html
+  🔗 https://javaevolved.dev/errors/helpful-npe.html
   
   #Java #JavaEvolved

--- a/social/tweets/errors/multi-catch.yaml
+++ b/social/tweets/errors/multi-catch.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Separate Catch Blocks → Multi-catch (JDK 7+)
   
-  🔗 https://javaevolved.github.io/errors/multi-catch.html
+  🔗 https://javaevolved.dev/errors/multi-catch.html
   
   #Java #JavaEvolved

--- a/social/tweets/errors/null-in-switch.yaml
+++ b/social/tweets/errors/null-in-switch.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Guard Before Switch → case null (JDK 21+)
   
-  🔗 https://javaevolved.github.io/errors/null-in-switch.html
+  🔗 https://javaevolved.dev/errors/null-in-switch.html
   
   #Java #JavaEvolved

--- a/social/tweets/errors/optional-chaining.yaml
+++ b/social/tweets/errors/optional-chaining.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Nested Null Checks → Optional Pipeline (JDK 9+)
   
-  🔗 https://javaevolved.github.io/errors/optional-chaining.html
+  🔗 https://javaevolved.dev/errors/optional-chaining.html
   
   #Java #JavaEvolved

--- a/social/tweets/errors/optional-orelsethrow.yaml
+++ b/social/tweets/errors/optional-orelsethrow.yaml
@@ -5,6 +5,6 @@ text: |-
   
   get() or orElseThrow(supplier) → orElseThrow() (JDK 10+)
   
-  🔗 https://javaevolved.github.io/errors/optional-orelsethrow.html
+  🔗 https://javaevolved.dev/errors/optional-orelsethrow.html
   
   #Java #JavaEvolved

--- a/social/tweets/errors/record-based-errors.yaml
+++ b/social/tweets/errors/record-based-errors.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Map or Verbose Class → Error Records (JDK 16+)
   
-  🔗 https://javaevolved.github.io/errors/record-based-errors.html
+  🔗 https://javaevolved.dev/errors/record-based-errors.html
   
   #Java #JavaEvolved

--- a/social/tweets/errors/require-nonnull-else.yaml
+++ b/social/tweets/errors/require-nonnull-else.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Ternary Null Check → requireNonNullElse() (JDK 9+)
   
-  🔗 https://javaevolved.github.io/errors/require-nonnull-else.html
+  🔗 https://javaevolved.dev/errors/require-nonnull-else.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/deserialization-filters.yaml
+++ b/social/tweets/io/deserialization-filters.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Accept Everything → ObjectInputFilter (JDK 9+)
   
-  🔗 https://javaevolved.github.io/io/deserialization-filters.html
+  🔗 https://javaevolved.dev/io/deserialization-filters.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/explicit-charset-file-io.yaml
+++ b/social/tweets/io/explicit-charset-file-io.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Platform-default charset → Explicit standard charset (JDK 7+)
   
-  🔗 https://javaevolved.github.io/io/explicit-charset-file-io.html
+  🔗 https://javaevolved.dev/io/explicit-charset-file-io.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/file-memory-mapping.yaml
+++ b/social/tweets/io/file-memory-mapping.yaml
@@ -5,6 +5,6 @@ text: |-
   
   MappedByteBuffer → MemorySegment with Arena (JDK 22+)
   
-  🔗 https://javaevolved.github.io/io/file-memory-mapping.html
+  🔗 https://javaevolved.dev/io/file-memory-mapping.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/files-mismatch.yaml
+++ b/social/tweets/io/files-mismatch.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Byte Compare → Files.mismatch() (JDK 12+)
   
-  🔗 https://javaevolved.github.io/io/files-mismatch.html
+  🔗 https://javaevolved.dev/io/files-mismatch.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/finalizers-to-resource-cleanup.yaml
+++ b/social/tweets/io/finalizers-to-resource-cleanup.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Override finalize() → AutoCloseable and Cleaner (JDK 9+)
   
-  🔗 https://javaevolved.github.io/io/finalizers-to-resource-cleanup.html
+  🔗 https://javaevolved.dev/io/finalizers-to-resource-cleanup.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/http-client.yaml
+++ b/social/tweets/io/http-client.yaml
@@ -5,6 +5,6 @@ text: |-
   
   HttpURLConnection → HttpClient (JDK 11+)
   
-  🔗 https://javaevolved.github.io/io/http-client.html
+  🔗 https://javaevolved.dev/io/http-client.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/http-websocket-client.yaml
+++ b/social/tweets/io/http-websocket-client.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Third-party WebSocket client → java.net.http.WebSocket (JDK 11+)
   
-  🔗 https://javaevolved.github.io/io/http-websocket-client.html
+  🔗 https://javaevolved.dev/io/http-websocket-client.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/inputstream-transferto.yaml
+++ b/social/tweets/io/inputstream-transferto.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Copy Loop → transferTo() (JDK 9+)
   
-  🔗 https://javaevolved.github.io/io/inputstream-transferto.html
+  🔗 https://javaevolved.dev/io/inputstream-transferto.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/io-class-console-io.yaml
+++ b/social/tweets/io/io-class-console-io.yaml
@@ -5,6 +5,6 @@ text: |-
   
   System.out / Scanner → IO class (JDK 25+)
   
-  🔗 https://javaevolved.github.io/io/io-class-console-io.html
+  🔗 https://javaevolved.dev/io/io-class-console-io.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/path-of.yaml
+++ b/social/tweets/io/path-of.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Paths.get() → Path.of() (JDK 11+)
   
-  🔗 https://javaevolved.github.io/io/path-of.html
+  🔗 https://javaevolved.dev/io/path-of.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/reading-files.yaml
+++ b/social/tweets/io/reading-files.yaml
@@ -5,6 +5,6 @@ text: |-
   
   BufferedReader → Files.readString() (JDK 11+)
   
-  🔗 https://javaevolved.github.io/io/reading-files.html
+  🔗 https://javaevolved.dev/io/reading-files.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/try-with-resources-effectively-final.yaml
+++ b/social/tweets/io/try-with-resources-effectively-final.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Re-declare Variable → Effectively Final (JDK 9+)
   
-  🔗 https://javaevolved.github.io/io/try-with-resources-effectively-final.html
+  🔗 https://javaevolved.dev/io/try-with-resources-effectively-final.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/url-constructors-to-uri.yaml
+++ b/social/tweets/io/url-constructors-to-uri.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Direct URL construction → URI then URL (JDK 20+)
   
-  🔗 https://javaevolved.github.io/io/url-constructors-to-uri.html
+  🔗 https://javaevolved.dev/io/url-constructors-to-uri.html
   
   #Java #JavaEvolved

--- a/social/tweets/io/writing-files.yaml
+++ b/social/tweets/io/writing-files.yaml
@@ -5,6 +5,6 @@ text: |-
   
   FileWriter + BufferedWriter → Files.writeString() (JDK 11+)
   
-  🔗 https://javaevolved.github.io/io/writing-files.html
+  🔗 https://javaevolved.dev/io/writing-files.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/anonymous-classes-to-lambdas.yaml
+++ b/social/tweets/language/anonymous-classes-to-lambdas.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Anonymous class → Method reference (JDK 8+)
   
-  🔗 https://javaevolved.github.io/language/anonymous-classes-to-lambdas.html
+  🔗 https://javaevolved.dev/language/anonymous-classes-to-lambdas.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/call-c-from-java.yaml
+++ b/social/tweets/language/call-c-from-java.yaml
@@ -5,6 +5,6 @@ text: |-
   
   JNI (Java Native Interface) → FFM (Foreign Function & Memory API) (JDK 22+)
   
-  🔗 https://javaevolved.github.io/language/call-c-from-java.html
+  🔗 https://javaevolved.dev/language/call-c-from-java.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/compact-canonical-constructor.yaml
+++ b/social/tweets/language/compact-canonical-constructor.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Explicit constructor validation → Compact constructor (JDK 16+)
   
-  🔗 https://javaevolved.github.io/language/compact-canonical-constructor.html
+  🔗 https://javaevolved.dev/language/compact-canonical-constructor.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/compact-source-files.yaml
+++ b/social/tweets/language/compact-source-files.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Main Class Ceremony → void main() (JDK 25+)
   
-  🔗 https://javaevolved.github.io/language/compact-source-files.html
+  🔗 https://javaevolved.dev/language/compact-source-files.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/default-interface-methods.yaml
+++ b/social/tweets/language/default-interface-methods.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Abstract classes for shared behavior → Default methods on interfaces (JDK 8+)
   
-  🔗 https://javaevolved.github.io/language/default-interface-methods.html
+  🔗 https://javaevolved.dev/language/default-interface-methods.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/diamond-operator.yaml
+++ b/social/tweets/language/diamond-operator.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Repeat Type Args → Diamond <> (JDK 9+)
   
-  🔗 https://javaevolved.github.io/language/diamond-operator.html
+  🔗 https://javaevolved.dev/language/diamond-operator.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/exhaustive-switch.yaml
+++ b/social/tweets/language/exhaustive-switch.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Mandatory default → Sealed Exhaustiveness (JDK 21+)
   
-  🔗 https://javaevolved.github.io/language/exhaustive-switch.html
+  🔗 https://javaevolved.dev/language/exhaustive-switch.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/flexible-constructor-bodies.yaml
+++ b/social/tweets/language/flexible-constructor-bodies.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Validate After super() → Code Before super() (JDK 25+)
   
-  🔗 https://javaevolved.github.io/language/flexible-constructor-bodies.html
+  🔗 https://javaevolved.dev/language/flexible-constructor-bodies.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/guarded-patterns.yaml
+++ b/social/tweets/language/guarded-patterns.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Nested if → when Clause (JDK 21+)
   
-  🔗 https://javaevolved.github.io/language/guarded-patterns.html
+  🔗 https://javaevolved.dev/language/guarded-patterns.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/markdown-javadoc-comments.yaml
+++ b/social/tweets/language/markdown-javadoc-comments.yaml
@@ -5,6 +5,6 @@ text: |-
   
   HTML-based Javadoc → Markdown Javadoc (JDK 23+)
   
-  🔗 https://javaevolved.github.io/language/markdown-javadoc-comments.html
+  🔗 https://javaevolved.dev/language/markdown-javadoc-comments.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/module-import-declarations.yaml
+++ b/social/tweets/language/module-import-declarations.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Many Imports → import module (JDK 25+)
   
-  🔗 https://javaevolved.github.io/language/module-import-declarations.html
+  🔗 https://javaevolved.dev/language/module-import-declarations.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/pattern-matching-instanceof.yaml
+++ b/social/tweets/language/pattern-matching-instanceof.yaml
@@ -5,6 +5,6 @@ text: |-
   
   instanceof + Cast → Pattern Variable (JDK 16+)
   
-  🔗 https://javaevolved.github.io/language/pattern-matching-instanceof.html
+  🔗 https://javaevolved.dev/language/pattern-matching-instanceof.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/pattern-matching-switch.yaml
+++ b/social/tweets/language/pattern-matching-switch.yaml
@@ -5,6 +5,6 @@ text: |-
   
   if-else Chain → Type Patterns (JDK 21+)
   
-  🔗 https://javaevolved.github.io/language/pattern-matching-switch.html
+  🔗 https://javaevolved.dev/language/pattern-matching-switch.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/primitive-types-in-patterns.yaml
+++ b/social/tweets/language/primitive-types-in-patterns.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Range Checks → Primitive Patterns (JDK 25+)
   
-  🔗 https://javaevolved.github.io/language/primitive-types-in-patterns.html
+  🔗 https://javaevolved.dev/language/primitive-types-in-patterns.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/private-interface-methods.yaml
+++ b/social/tweets/language/private-interface-methods.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Duplicated Logic → Private Methods (JDK 9+)
   
-  🔗 https://javaevolved.github.io/language/private-interface-methods.html
+  🔗 https://javaevolved.dev/language/private-interface-methods.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/raw-collections-to-generics.yaml
+++ b/social/tweets/language/raw-collections-to-generics.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Raw collections → Generic collections (JDK 5+)
   
-  🔗 https://javaevolved.github.io/language/raw-collections-to-generics.html
+  🔗 https://javaevolved.dev/language/raw-collections-to-generics.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/record-patterns.yaml
+++ b/social/tweets/language/record-patterns.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Access → Destructuring (JDK 21+)
   
-  🔗 https://javaevolved.github.io/language/record-patterns.html
+  🔗 https://javaevolved.dev/language/record-patterns.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/records-for-data-classes.yaml
+++ b/social/tweets/language/records-for-data-classes.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Verbose POJO → record (JDK 16+)
   
-  🔗 https://javaevolved.github.io/language/records-for-data-classes.html
+  🔗 https://javaevolved.dev/language/records-for-data-classes.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/sealed-classes.yaml
+++ b/social/tweets/language/sealed-classes.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Open Hierarchy → sealed permits (JDK 17+)
   
-  🔗 https://javaevolved.github.io/language/sealed-classes.html
+  🔗 https://javaevolved.dev/language/sealed-classes.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/static-members-in-inner-classes.yaml
+++ b/social/tweets/language/static-members-in-inner-classes.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Must use static nested class → Static members in inner classes (JDK 16+)
   
-  🔗 https://javaevolved.github.io/language/static-members-in-inner-classes.html
+  🔗 https://javaevolved.dev/language/static-members-in-inner-classes.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/static-methods-in-interfaces.yaml
+++ b/social/tweets/language/static-methods-in-interfaces.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Utility classes → Interface static methods (JDK 8+)
   
-  🔗 https://javaevolved.github.io/language/static-methods-in-interfaces.html
+  🔗 https://javaevolved.dev/language/static-methods-in-interfaces.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/switch-expressions.yaml
+++ b/social/tweets/language/switch-expressions.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Switch Statement → Switch Expression (JDK 14+)
   
-  🔗 https://javaevolved.github.io/language/switch-expressions.html
+  🔗 https://javaevolved.dev/language/switch-expressions.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/text-blocks-for-multiline-strings.yaml
+++ b/social/tweets/language/text-blocks-for-multiline-strings.yaml
@@ -5,6 +5,6 @@ text: |-
   
   String Concatenation → Text Blocks (JDK 15+)
   
-  🔗 https://javaevolved.github.io/language/text-blocks-for-multiline-strings.html
+  🔗 https://javaevolved.dev/language/text-blocks-for-multiline-strings.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/type-inference-with-var.yaml
+++ b/social/tweets/language/type-inference-with-var.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Explicit Types → var keyword (JDK 10+)
   
-  🔗 https://javaevolved.github.io/language/type-inference-with-var.html
+  🔗 https://javaevolved.dev/language/type-inference-with-var.html
   
   #Java #JavaEvolved

--- a/social/tweets/language/unnamed-variables.yaml
+++ b/social/tweets/language/unnamed-variables.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Unused Variable → _ Placeholder (JDK 22+)
   
-  🔗 https://javaevolved.github.io/language/unnamed-variables.html
+  🔗 https://javaevolved.dev/language/unnamed-variables.html
   
   #Java #JavaEvolved

--- a/social/tweets/security/key-derivation-functions.yaml
+++ b/social/tweets/security/key-derivation-functions.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual PBKDF2 → KDF API (JDK 25+)
   
-  🔗 https://javaevolved.github.io/security/key-derivation-functions.html
+  🔗 https://javaevolved.dev/security/key-derivation-functions.html
   
   #Java #JavaEvolved

--- a/social/tweets/security/pem-encoding.yaml
+++ b/social/tweets/security/pem-encoding.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Base64 + Headers → PEM API (JDK 25+)
   
-  🔗 https://javaevolved.github.io/security/pem-encoding.html
+  🔗 https://javaevolved.dev/security/pem-encoding.html
   
   #Java #JavaEvolved

--- a/social/tweets/security/random-generator.yaml
+++ b/social/tweets/security/random-generator.yaml
@@ -5,6 +5,6 @@ text: |-
   
   new Random() / ThreadLocalRandom → RandomGenerator factory (JDK 17+)
   
-  🔗 https://javaevolved.github.io/security/random-generator.html
+  🔗 https://javaevolved.dev/security/random-generator.html
   
   #Java #JavaEvolved

--- a/social/tweets/security/security-manager-migration.yaml
+++ b/social/tweets/security/security-manager-migration.yaml
@@ -5,6 +5,6 @@ text: |-
   
   SecurityManager checks → Explicit authorization (JDK 24+)
   
-  🔗 https://javaevolved.github.io/security/security-manager-migration.html
+  🔗 https://javaevolved.dev/security/security-manager-migration.html
   
   #Java #JavaEvolved

--- a/social/tweets/security/standard-base64.yaml
+++ b/social/tweets/security/standard-base64.yaml
@@ -5,6 +5,6 @@ text: |-
   
   sun.misc encoder → Standard Base64 API (JDK 8+)
   
-  🔗 https://javaevolved.github.io/security/standard-base64.html
+  🔗 https://javaevolved.dev/security/standard-base64.html
   
   #Java #JavaEvolved

--- a/social/tweets/security/strong-random.yaml
+++ b/social/tweets/security/strong-random.yaml
@@ -5,6 +5,6 @@ text: |-
   
   new SecureRandom() → getInstanceStrong() (JDK 9+)
   
-  🔗 https://javaevolved.github.io/security/strong-random.html
+  🔗 https://javaevolved.dev/security/strong-random.html
   
   #Java #JavaEvolved

--- a/social/tweets/security/tls-default.yaml
+++ b/social/tweets/security/tls-default.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual TLS Config → TLS 1.3 Default (JDK 11+)
   
-  🔗 https://javaevolved.github.io/security/tls-default.html
+  🔗 https://javaevolved.dev/security/tls-default.html
   
   #Java #JavaEvolved

--- a/social/tweets/streams/collectors-flatmapping.yaml
+++ b/social/tweets/streams/collectors-flatmapping.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Nested flatMap → flatMapping() (JDK 9+)
   
-  🔗 https://javaevolved.github.io/streams/collectors-flatmapping.html
+  🔗 https://javaevolved.dev/streams/collectors-flatmapping.html
   
   #Java #JavaEvolved

--- a/social/tweets/streams/optional-ifpresentorelse.yaml
+++ b/social/tweets/streams/optional-ifpresentorelse.yaml
@@ -5,6 +5,6 @@ text: |-
   
   if/else on Optional → ifPresentOrElse() (JDK 9+)
   
-  🔗 https://javaevolved.github.io/streams/optional-ifpresentorelse.html
+  🔗 https://javaevolved.dev/streams/optional-ifpresentorelse.html
   
   #Java #JavaEvolved

--- a/social/tweets/streams/optional-or.yaml
+++ b/social/tweets/streams/optional-or.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Nested Fallback → .or() chain (JDK 9+)
   
-  🔗 https://javaevolved.github.io/streams/optional-or.html
+  🔗 https://javaevolved.dev/streams/optional-or.html
   
   #Java #JavaEvolved

--- a/social/tweets/streams/predicate-not.yaml
+++ b/social/tweets/streams/predicate-not.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Lambda negation → Predicate.not() (JDK 11+)
   
-  🔗 https://javaevolved.github.io/streams/predicate-not.html
+  🔗 https://javaevolved.dev/streams/predicate-not.html
   
   #Java #JavaEvolved

--- a/social/tweets/streams/stream-gatherers.yaml
+++ b/social/tweets/streams/stream-gatherers.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Custom Collector → gather() (JDK 24+)
   
-  🔗 https://javaevolved.github.io/streams/stream-gatherers.html
+  🔗 https://javaevolved.dev/streams/stream-gatherers.html
   
   #Java #JavaEvolved

--- a/social/tweets/streams/stream-iterate-predicate.yaml
+++ b/social/tweets/streams/stream-iterate-predicate.yaml
@@ -5,6 +5,6 @@ text: |-
   
   iterate + limit → iterate(seed, pred, op) (JDK 9+)
   
-  🔗 https://javaevolved.github.io/streams/stream-iterate-predicate.html
+  🔗 https://javaevolved.dev/streams/stream-iterate-predicate.html
   
   #Java #JavaEvolved

--- a/social/tweets/streams/stream-mapmulti.yaml
+++ b/social/tweets/streams/stream-mapmulti.yaml
@@ -5,6 +5,6 @@ text: |-
   
   flatMap + List → mapMulti() (JDK 16+)
   
-  🔗 https://javaevolved.github.io/streams/stream-mapmulti.html
+  🔗 https://javaevolved.dev/streams/stream-mapmulti.html
   
   #Java #JavaEvolved

--- a/social/tweets/streams/stream-of-nullable.yaml
+++ b/social/tweets/streams/stream-of-nullable.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Null Check → ofNullable() (JDK 9+)
   
-  🔗 https://javaevolved.github.io/streams/stream-of-nullable.html
+  🔗 https://javaevolved.dev/streams/stream-of-nullable.html
   
   #Java #JavaEvolved

--- a/social/tweets/streams/stream-takewhile-dropwhile.yaml
+++ b/social/tweets/streams/stream-takewhile-dropwhile.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Loop → takeWhile/dropWhile (JDK 9+)
   
-  🔗 https://javaevolved.github.io/streams/stream-takewhile-dropwhile.html
+  🔗 https://javaevolved.dev/streams/stream-takewhile-dropwhile.html
   
   #Java #JavaEvolved

--- a/social/tweets/streams/stream-tolist.yaml
+++ b/social/tweets/streams/stream-tolist.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Collectors.toList() → .toList() (JDK 16+)
   
-  🔗 https://javaevolved.github.io/streams/stream-tolist.html
+  🔗 https://javaevolved.dev/streams/stream-tolist.html
   
   #Java #JavaEvolved

--- a/social/tweets/streams/virtual-thread-executor.yaml
+++ b/social/tweets/streams/virtual-thread-executor.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Fixed Thread Pool → Virtual Thread Executor (JDK 21+)
   
-  🔗 https://javaevolved.github.io/streams/virtual-thread-executor.html
+  🔗 https://javaevolved.dev/streams/virtual-thread-executor.html
   
   #Java #JavaEvolved

--- a/social/tweets/strings/string-chars-stream.yaml
+++ b/social/tweets/strings/string-chars-stream.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Loop → chars() Stream (JDK 9+)
   
-  🔗 https://javaevolved.github.io/strings/string-chars-stream.html
+  🔗 https://javaevolved.dev/strings/string-chars-stream.html
   
   #Java #JavaEvolved

--- a/social/tweets/strings/string-formatted.yaml
+++ b/social/tweets/strings/string-formatted.yaml
@@ -5,6 +5,6 @@ text: |-
   
   String.format() → formatted() (JDK 15+)
   
-  🔗 https://javaevolved.github.io/strings/string-formatted.html
+  🔗 https://javaevolved.dev/strings/string-formatted.html
   
   #Java #JavaEvolved

--- a/social/tweets/strings/string-indent-transform.yaml
+++ b/social/tweets/strings/string-indent-transform.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Manual Indentation → indent() / transform() (JDK 12+)
   
-  🔗 https://javaevolved.github.io/strings/string-indent-transform.html
+  🔗 https://javaevolved.dev/strings/string-indent-transform.html
   
   #Java #JavaEvolved

--- a/social/tweets/strings/string-isblank.yaml
+++ b/social/tweets/strings/string-isblank.yaml
@@ -5,6 +5,6 @@ text: |-
   
   trim().isEmpty() → isBlank() (JDK 11+)
   
-  🔗 https://javaevolved.github.io/strings/string-isblank.html
+  🔗 https://javaevolved.dev/strings/string-isblank.html
   
   #Java #JavaEvolved

--- a/social/tweets/strings/string-lines.yaml
+++ b/social/tweets/strings/string-lines.yaml
@@ -5,6 +5,6 @@ text: |-
   
   split("\\n") → lines() (JDK 11+)
   
-  🔗 https://javaevolved.github.io/strings/string-lines.html
+  🔗 https://javaevolved.dev/strings/string-lines.html
   
   #Java #JavaEvolved

--- a/social/tweets/strings/string-repeat.yaml
+++ b/social/tweets/strings/string-repeat.yaml
@@ -5,6 +5,6 @@ text: |-
   
   StringBuilder Loop → repeat() (JDK 11+)
   
-  🔗 https://javaevolved.github.io/strings/string-repeat.html
+  🔗 https://javaevolved.dev/strings/string-repeat.html
   
   #Java #JavaEvolved

--- a/social/tweets/strings/string-strip.yaml
+++ b/social/tweets/strings/string-strip.yaml
@@ -5,6 +5,6 @@ text: |-
   
   trim() → strip() (JDK 11+)
   
-  🔗 https://javaevolved.github.io/strings/string-strip.html
+  🔗 https://javaevolved.dev/strings/string-strip.html
   
   #Java #JavaEvolved

--- a/social/tweets/tooling/aot-class-preloading.yaml
+++ b/social/tweets/tooling/aot-class-preloading.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Cold Start Every Time → AOT Cache (JDK 25+)
   
-  🔗 https://javaevolved.github.io/tooling/aot-class-preloading.html
+  🔗 https://javaevolved.dev/tooling/aot-class-preloading.html
   
   #Java #JavaEvolved

--- a/social/tweets/tooling/built-in-http-server.yaml
+++ b/social/tweets/tooling/built-in-http-server.yaml
@@ -5,6 +5,6 @@ text: |-
   
   External Server / Framework → jwebserver CLI (JDK 18+)
   
-  🔗 https://javaevolved.github.io/tooling/built-in-http-server.html
+  🔗 https://javaevolved.dev/tooling/built-in-http-server.html
   
   #Java #JavaEvolved

--- a/social/tweets/tooling/class-file-api.yaml
+++ b/social/tweets/tooling/class-file-api.yaml
@@ -5,6 +5,6 @@ text: |-
   
   ASM ClassReader → Class-File API (JDK 24+)
   
-  🔗 https://javaevolved.github.io/tooling/class-file-api.html
+  🔗 https://javaevolved.dev/tooling/class-file-api.html
   
   #Java #JavaEvolved

--- a/social/tweets/tooling/class-newinstance-to-constructor.yaml
+++ b/social/tweets/tooling/class-newinstance-to-constructor.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Class.newInstance() → Explicit constructor lookup (JDK 9+)
   
-  🔗 https://javaevolved.github.io/tooling/class-newinstance-to-constructor.html
+  🔗 https://javaevolved.dev/tooling/class-newinstance-to-constructor.html
   
   #Java #JavaEvolved

--- a/social/tweets/tooling/compact-object-headers.yaml
+++ b/social/tweets/tooling/compact-object-headers.yaml
@@ -5,6 +5,6 @@ text: |-
   
   128-bit Headers → 64-bit Headers (JDK 25+)
   
-  🔗 https://javaevolved.github.io/tooling/compact-object-headers.html
+  🔗 https://javaevolved.dev/tooling/compact-object-headers.html
   
   #Java #JavaEvolved

--- a/social/tweets/tooling/jfr-profiling.yaml
+++ b/social/tweets/tooling/jfr-profiling.yaml
@@ -5,6 +5,6 @@ text: |-
   
   External Profiler → Java Flight Recorder (JDK 9+)
   
-  🔗 https://javaevolved.github.io/tooling/jfr-profiling.html
+  🔗 https://javaevolved.dev/tooling/jfr-profiling.html
   
   #Java #JavaEvolved

--- a/social/tweets/tooling/jshell-prototyping.yaml
+++ b/social/tweets/tooling/jshell-prototyping.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Create File + Compile + Run → jshell REPL (JDK 9+)
   
-  🔗 https://javaevolved.github.io/tooling/jshell-prototyping.html
+  🔗 https://javaevolved.dev/tooling/jshell-prototyping.html
   
   #Java #JavaEvolved

--- a/social/tweets/tooling/junit6-with-jspecify.yaml
+++ b/social/tweets/tooling/junit6-with-jspecify.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Unannotated API → @NullMarked API (JDK 17+)
   
-  🔗 https://javaevolved.github.io/tooling/junit6-with-jspecify.html
+  🔗 https://javaevolved.dev/tooling/junit6-with-jspecify.html
   
   #Java #JavaEvolved

--- a/social/tweets/tooling/multi-file-source.yaml
+++ b/social/tweets/tooling/multi-file-source.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Compile All First → Source Launcher (JDK 22+)
   
-  🔗 https://javaevolved.github.io/tooling/multi-file-source.html
+  🔗 https://javaevolved.dev/tooling/multi-file-source.html
   
   #Java #JavaEvolved

--- a/social/tweets/tooling/runtime-exec-to-process-builder.yaml
+++ b/social/tweets/tooling/runtime-exec-to-process-builder.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Runtime.exec(String) → ProcessBuilder (JDK 5+)
   
-  🔗 https://javaevolved.github.io/tooling/runtime-exec-to-process-builder.html
+  🔗 https://javaevolved.dev/tooling/runtime-exec-to-process-builder.html
   
   #Java #JavaEvolved

--- a/social/tweets/tooling/single-file-execution.yaml
+++ b/social/tweets/tooling/single-file-execution.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Two-Step Compile → Direct Launch (JDK 11+)
   
-  🔗 https://javaevolved.github.io/tooling/single-file-execution.html
+  🔗 https://javaevolved.dev/tooling/single-file-execution.html
   
   #Java #JavaEvolved

--- a/social/tweets/tooling/stack-walker.yaml
+++ b/social/tweets/tooling/stack-walker.yaml
@@ -5,6 +5,6 @@ text: |-
   
   Thread.getStackTrace() → StackWalker (JDK 9+)
   
-  🔗 https://javaevolved.github.io/tooling/stack-walker.html
+  🔗 https://javaevolved.dev/tooling/stack-walker.html
   
   #Java #JavaEvolved


### PR DESCRIPTION
The website now uses javaevolved.dev, so social posts should no longer direct readers to the legacy GitHub Pages domain.

This updates all existing tweet drafts and changes the social queue generator's base URL so newly generated drafts consistently link to javaevolved.dev.